### PR TITLE
Add Cosmos Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,3 @@ jobs:
       - name: Run Shell 🐚
         run: |
           nix develop
-
-      - name: Build All 🛠️
-        run: |
-          nix build .#hermes
-          nix build .#gaia
-          nix build .#gm
-          nix build .#cosmovisor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,23 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Link Cachix 🔌
+        uses: cachix/cachix-action@v10
+        with:
+          name: cosmos
+          authToken: '${{ secrets.COSMOS_CACHE_KEY }}'
+
       - name: Check 🔎
         run: |
           nix flake check
+
+      - name: Run Shell 🐚
+        run: |
+          nix develop
+
+      - name: Build All 🛠️
+        run: |
+          nix build .#hermes
+          nix build .#gaia
+          nix build .#gm
+          nix build .#cosmovisor

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result*
 /.pre-commit-config.yaml
+dev-profile*

--- a/README.md
+++ b/README.md
@@ -31,12 +31,27 @@ echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
 
 [Setup Caches](https://nixos.org/manual/nix/unstable/package-management/sharing-packages.html)
 
+##### Cache Setup with Cachix
+
+With nix installed you can run `nix-env -iA cachix -f https://cachix.org/api/v1/install`.
+You can check that this worked by running `cachix --version`.
+
+You can now run these commans to add all of our cachix caches:
+
+```bash
+$ cachix use cosmos
+$ cachix use pre-commit-hooks
+$ cachix use nix-community
+```
+
+##### Manual Cache Setup
+
 Add these lines to your Nix config (either ~/.config/nix/nix.conf [for MacOS] or
 /etc/nix/nix.conf [for flavors of Linux, depending on your distro]):
 
 ```
-extra-substituters = https://cache.nixos.org https://nix-community.cachix.org https://pre-commit-hooks.cachix.org
-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= pre-commit-hooks.cachix.org-1:Pkk3Panw5AW24TOv6kz3PvLhlH8puAsJTBbOPmBo7Rc=
+extra-substituters = https://cache.nixos.org https://nix-community.cachix.org https://pre-commit-hooks.cachix.org https://cosmos.cachix.org
+trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= pre-commit-hooks.cachix.org-1:Pkk3Panw5AW24TOv6kz3PvLhlH8puAsJTBbOPmBo7Rc= cosmos.cachix.org-1:T5U9yg6u2kM48qAOXHO/ayhO8IWFnv0LOhNcq0yKuR8=
 cores = 4 # NB: You may want to increase this on machines with more cores
 ```
 
@@ -57,10 +72,12 @@ Note, you can add the suggested binary caches in addition to your existing ones.
       "https://cache.nixos.org"
       "https://nix-community.cachix.org"
       "https://pre-commit-hooks.cachix.org"
+      "https://cosmos.cachix.org"
     ];
     binaryCachePublicKeys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "pre-commit-hooks.cachix.org-1:Pkk3Panw5AW24TOv6kz3PvLhlH8puAsJTBbOPmBo7Rc="
+      "cosmos.cachix.org-1:T5U9yg6u2kM48qAOXHO/ayhO8IWFnv0LOhNcq0yKuR8="
     ];
    };
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cosmos-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1626794131,
-        "narHash": "sha256-g6dJz/6tTtrl5Z7jrxK+X78KB5UadlmqBVZT/f5DA0M=",
+        "lastModified": 1630679367,
+        "narHash": "sha256-tD1ghhs/kojua5z5H6Bf6pgSDEuZTEWZN+uxzeuVqgs=",
         "owner": "cosmos",
         "repo": "cosmos-sdk",
-        "rev": "12e4be34fbd2414b10756997ca3769ebaaf6bdea",
+        "rev": "bfba5491f39f0e0af100480a3194a30c2dc4b9c3",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -153,6 +153,22 @@
       "locked": {
         "lastModified": 1631315520,
         "narHash": "sha256-Y8j0JYtZMifrHaWdTfTp1mYVXZ2PLJO/P0XZxMvo7KU=",
+        "lastModified": 1630879492,
+        "narHash": "sha256-QSqIyHww3WEargEPAGuuJ4TXShPg65tKBXcUj5I08AU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1a8359692853f50121a8c236e112fdc1ba48349e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1626852498,
+        "narHash": "sha256-lOXUJvi0FJUXHTVSiC5qsMRtEUgqM4mGZpMESLuGhmo=",
         "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "b72ad04a8a324697d3fb92e19cd840379a902813",
@@ -165,7 +181,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1631315520,
         "narHash": "sha256-Y8j0JYtZMifrHaWdTfTp1mYVXZ2PLJO/P0XZxMvo7KU=",
@@ -181,7 +197,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1619531122,
         "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
@@ -280,4 +296,3 @@
   "root": "root",
   "version": 7
 }
-

--- a/flake.lock
+++ b/flake.lock
@@ -280,3 +280,4 @@
   "root": "root",
   "version": 7
 }
+

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cosmos-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1630679367,
-        "narHash": "sha256-tD1ghhs/kojua5z5H6Bf6pgSDEuZTEWZN+uxzeuVqgs=",
+        "lastModified": 1626794131,
+        "narHash": "sha256-g6dJz/6tTtrl5Z7jrxK+X78KB5UadlmqBVZT/f5DA0M=",
         "owner": "cosmos",
         "repo": "cosmos-sdk",
-        "rev": "bfba5491f39f0e0af100480a3194a30c2dc4b9c3",
+        "rev": "12e4be34fbd2414b10756997ca3769ebaaf6bdea",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {

--- a/gm/default.nix
+++ b/gm/default.nix
@@ -11,7 +11,6 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
 
-    ls -la $out
     ln -s ${ibc-rs-src}/scripts/gm/bin/gm $out/bin/gm
     ln -s ${ibc-rs-src}/scripts/gm/bin/lib-gm $out/bin/lib-gm
     ln -s ${ibc-rs-src}/scripts/gm/bin/shell-support $out/bin/shell-support


### PR DESCRIPTION
Closes https://github.com/informalsystems/cosmos.nix/issues/2
Closes https://github.com/informalsystems/cosmos.nix/issues/3

At some point I would like to provide a secret to this repo called `COSMOS_CACHE_KEY`. I don't have access to do this yet. It should be fine, since github actions are running on my fork as well, and therefore the cache should get pushed on every PR I make.