### PR TITLE
Add Remote Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ Note, you can add the suggested binary caches in addition to your existing ones.
    };
 ```
 
+## Shell
+
+If you are just here for a remote nix shell (a development environment where
+you don't need to clone the repo) you can run the following command:
+
+```bash
+nix develop github:informalsystems/cosmos.nix
+```
+
+This will build the development environment. The environment will then be
+cached in your nix store and should be very fast. If you want to pull the
+latest development environment you should run:
+
+```bash
+nix develop github:informalsystems/cosmos.nix --refresh
+```
+
 ## Sources
 
 Right now only the sources of the upstream projects are given as a Nix

--- a/flake.lock
+++ b/flake.lock
@@ -296,3 +296,4 @@
   "root": "root",
   "version": 7
 }
+

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cosmos-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1626794131,
-        "narHash": "sha256-g6dJz/6tTtrl5Z7jrxK+X78KB5UadlmqBVZT/f5DA0M=",
+        "lastModified": 1630679367,
+        "narHash": "sha256-tD1ghhs/kojua5z5H6Bf6pgSDEuZTEWZN+uxzeuVqgs=",
         "owner": "cosmos",
         "repo": "cosmos-sdk",
-        "rev": "12e4be34fbd2414b10756997ca3769ebaaf6bdea",
+        "rev": "bfba5491f39f0e0af100480a3194a30c2dc4b9c3",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -133,6 +133,24 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1629707199,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1625191069,
@@ -296,4 +314,3 @@
   "root": "root",
   "version": 7
 }
-

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cosmos-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1630679367,
-        "narHash": "sha256-tD1ghhs/kojua5z5H6Bf6pgSDEuZTEWZN+uxzeuVqgs=",
+        "lastModified": 1626794131,
+        "narHash": "sha256-g6dJz/6tTtrl5Z7jrxK+X78KB5UadlmqBVZT/f5DA0M=",
         "owner": "cosmos",
         "repo": "cosmos-sdk",
-        "rev": "bfba5491f39f0e0af100480a3194a30c2dc4b9c3",
+        "rev": "12e4be34fbd2414b10756997ca3769ebaaf6bdea",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -161,10 +161,13 @@
           in
           pkgs.mkShell {
             shellHook = ''
-              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename "$(${pkgs.git}/bin/git remote get-url origin 2> /dev/null)")"
-              if [[ $GIT_REMOTE == *"cosmos.nix"* ]]
+              GIT_REMOTE="$(${pkgs.git}/bin/git remote get-url origin 2> /dev/null)"
+              REMOTE_BASENAME="$(${pkgs.coreutils}/bin/basename $GIT_REMOTE)"
+              if [[ $REMOTE_BASENAME == *"cosmos.nix"* && (-d .git || -f .git) ]]
               then
                 ${self.checks.${system}.pre-commit-check.shellHook}
+              else
+                echo "You are in a remote cosmos.nix shell"
               fi
             '';
             nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
           pkgs.mkShell {
             shellHook = ''
               GIT_REMOTE="$(${pkgs.git}/bin/git remote get-url origin 2> /dev/null)"
-              REMOTE_BASENAME="$(${pkgs.coreutils}/bin/basename $GIT_REMOTE)"
+              REMOTE_BASENAME="$(${pkgs.coreutils}/bin/basename "$GIT_REMOTE")"
               if [[ $REMOTE_BASENAME == *"cosmos.nix"* && (-d .git || -f .git) ]]
               then
                 ${self.checks.${system}.pre-commit-check.shellHook}

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,14 @@
             '';
           in
           pkgs.mkShell {
-            shellHook = self.checks.${system}.pre-commit-check.shellHook;
+            shellHook = ''
+              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename $(${pkgs.git}/bin/git remote get-url origin))"
+              if [[ $GIT_REMOTE == *"cosmos.nix"* ]];
+              then
+                echo "Installing pre-commit hooks"
+                ${self.checks.${system}.pre-commit-check.shellHook}
+              fi
+            '';
             nativeBuildInputs = with pkgs; [
               rustc
               cargo

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
           in
           pkgs.mkShell {
             shellHook = ''
-              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename $(${pkgs.git}/bin/git remote get-url origin))"
+              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename $(${pkgs.git}/bin/git remote get-url origin) 2> /dev/null)"
               if [[ $GIT_REMOTE == *"cosmos.nix"* ]];
               then
                 echo "Installing pre-commit hooks"

--- a/flake.nix
+++ b/flake.nix
@@ -161,10 +161,9 @@
           in
           pkgs.mkShell {
             shellHook = ''
-              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename $(${pkgs.git}/bin/git remote get-url origin) 2> /dev/null)"
-              if [[ $GIT_REMOTE == *"cosmos.nix"* ]];
+              GIT_REMOTE="$(${pkgs.coreutils}/bin/basename "$(${pkgs.git}/bin/git remote get-url origin 2> /dev/null)")"
+              if [[ $GIT_REMOTE == *"cosmos.nix"* ]]
               then
-                echo "Installing pre-commit hooks"
                 ${self.checks.${system}.pre-commit-check.shellHook}
               fi
             '';


### PR DESCRIPTION
This PR adds a more robust `shellHook` so that developers can enter the nix shell remotely. A "remote shell" is what I am calling a shell that is entered without cloning the repo. I have added instructions in the README on this. This should make things _much_ more convenient for developers who don't want to futz with nix or this repo (note: they will still have to install nix on their machine).