### PR TITLE
Improve Apalache build steps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     "apalache-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1649641733,
-        "narHash": "sha256-2CsKxrl8gJLxBojv1QJIdGqktoaSb/EkC4dFqF7zoEg=",
+        "lastModified": 1650241137,
+        "narHash": "sha256-15jzwbBc7ByxHJbpHmIukSNvih9oxTXeinNamgXirCU=",
         "owner": "informalsystems",
         "repo": "apalache",
-        "rev": "eec238683fde4590c060fa572429c577638a1a44",
+        "rev": "40d9ec66b3defe8e72803ca9241a73366497eeee",
         "type": "github"
       },
       "original": {
         "owner": "informalsystems",
-        "ref": "v0.23.1",
+        "ref": "v0.24.0",
         "repo": "apalache",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
     wasmvm_0_16_3-src.url = github:CosmWasm/wasmvm/v0.16.3;
 
     apalache-src.flake = false;
-    apalache-src.url = github:informalsystems/apalache/v0.23.1;
+    apalache-src.url = github:informalsystems/apalache/v0.24.0;
   };
 
   outputs = inputs:

--- a/resources/apalache.nix
+++ b/resources/apalache.nix
@@ -32,7 +32,7 @@ in
     pname = "apalache";
     inherit version;
 
-    depsSha256 = "sha256-xKLKlkOHysNtSCDtj9JKwLYyCCuRrc36+QsBWFjLnFI=";
+    depsSha256 = "sha256-9wGlIFmvKW4N8NQqhOlxjhl48JptHCSI8F8EFF9mYrw=";
 
     src = apalache-src;
 
@@ -41,14 +41,17 @@ in
     ];
 
     buildPhase = ''
-      sbt apalacheCurrentPackage
+      make dist
     '';
 
     installPhase = ''
       mkdir -p $out/lib
       mkdir -p $out/bin
+      mkdir -p target/out
 
-      cp -r target/universal/current-pkg/lib/apalache.jar $out/lib/apalache.jar
+      tar xf target/universal/apalache.tgz -C target/out
+
+      cp -r target/out/apalache/lib/apalache.jar $out/lib/apalache.jar
 
       cat > $out/bin/apalache-mc <<- EOM
       #!${pkgs.bash}/bin/bash


### PR DESCRIPTION
Use `make dist` instead of `sbt apalacheCurrentPackage` for building the package, as `apalacheCurrentPackage` does not fully install the package with all its dependencies.

Also updates Apalache version from `v0.23.1` to `v0.24.0`.