### PR TITLE
Update Gaia and ibc-go-simapp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,41 +149,7 @@
         "type": "github"
       }
     },
-    "gaia6_0_2-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645118548,
-        "narHash": "sha256-an1JVPCMcJgQYi+inx4MrAcwYjHTVFvDzw865pJc6C8=",
-        "owner": "cosmos",
-        "repo": "gaia",
-        "rev": "05f3795f196dd32e9233db97ed8742f8559cb483",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmos",
-        "ref": "v6.0.2",
-        "repo": "gaia",
-        "type": "github"
-      }
-    },
-    "gaia6_0_3-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645184577,
-        "narHash": "sha256-a24C1sooMj8mVGYYV2wL7P3kM7xj/MVzfeggj186PQo=",
-        "owner": "cosmos",
-        "repo": "gaia",
-        "rev": "8f5dd7549fd21b99099e100da043bd8919d37ac3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmos",
-        "ref": "v6.0.3",
-        "repo": "gaia",
-        "type": "github"
-      }
-    },
-    "gaia6_0_4-src": {
+    "gaia6-src": {
       "flake": false,
       "locked": {
         "lastModified": 1646904235,
@@ -203,33 +169,32 @@
     "gaia7-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1648134734,
-        "narHash": "sha256-A9EqVHR2GiyuemTrjeaJWyIm6e3XUQ3nSm9dBF9gwvk=",
+        "lastModified": 1649856981,
+        "narHash": "sha256-SQCKRnf56uNZp/TCJAkDdHTQNbHJNZXu6BmhXqtNvvs=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "79fcf71689358b6212ae91f41070de9669421cf5",
+        "rev": "0664d9ec7c7acbcd944174f2f5326a7df5654bdf",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.0.0",
+        "ref": "v7.0.1",
         "repo": "gaia",
         "type": "github"
       }
     },
-    "ibc-go-ics29-src": {
+    "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647958967,
-        "narHash": "sha256-QZ/BQ+qnz+dmosx7/bptIoAyufeWRdT2i420p2ujqf8=",
+        "lastModified": 1651571071,
+        "narHash": "sha256-AwTTN6p5/Q5tnoipuylv1qF8Gw4I7YHASLvIwtLxvLA=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "ab90f07e9a776a8aafe333a25f91fa43a0e42560",
+        "rev": "bd086506f9256c4d5776bc38d2e930b523eb5125",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "ics29-fee-middleware",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -468,11 +433,9 @@
         "flake-utils": "flake-utils",
         "gaia5-src": "gaia5-src",
         "gaia6-ordered-src": "gaia6-ordered-src",
-        "gaia6_0_2-src": "gaia6_0_2-src",
-        "gaia6_0_3-src": "gaia6_0_3-src",
-        "gaia6_0_4-src": "gaia6_0_4-src",
+        "gaia6-src": "gaia6-src",
         "gaia7-src": "gaia7-src",
-        "ibc-go-ics29-src": "ibc-go-ics29-src",
+        "ibc-go-main-src": "ibc-go-main-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",
         "ibc-rs-src": "ibc-rs-src",

--- a/flake.nix
+++ b/flake.nix
@@ -36,19 +36,13 @@
 
     # Chain Sources
     gaia7-src.flake = false;
-    gaia7-src.url = github:cosmos/gaia/v7.0.0;
-
-    gaia6_0_2-src.flake = false;
-    gaia6_0_2-src.url = github:cosmos/gaia/v6.0.2;
-
-    gaia6_0_3-src.flake = false;
-    gaia6_0_3-src.url = github:cosmos/gaia/v6.0.3;
+    gaia7-src.url = github:cosmos/gaia/v7.0.1;
 
     gaia6-ordered-src.flake = false;
     gaia6-ordered-src.url = github:informalsystems/gaia/v6.0.4-ordered;
 
-    gaia6_0_4-src.flake = false;
-    gaia6_0_4-src.url = github:cosmos/gaia/v6.0.4;
+    gaia6-src.flake = false;
+    gaia6-src.url = github:cosmos/gaia/v6.0.4;
 
     gaia5-src.flake = false;
     gaia5-src.url = github:cosmos/gaia/v5.0.8;
@@ -59,8 +53,8 @@
     ibc-go-v3-src.flake = false;
     ibc-go-v3-src.url = github:cosmos/ibc-go/v3.0.0;
 
-    ibc-go-ics29-src.flake = false;
-    ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-fee-middleware;
+    ibc-go-main-src.flake = false;
+    ibc-go-main-src.url = github:cosmos/ibc-go;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.45.0-rc1;

--- a/flake.nix
+++ b/flake.nix
@@ -174,22 +174,7 @@
           };
           gaia6 = mkApp {
             name = "gaia";
-            drv = packages.gaia6_0_4;
-            exePath = "/bin/gaiad";
-          };
-          gaia6_0_2 = mkApp {
-            name = "gaia";
-            drv = packages.gaia6_0_2;
-            exePath = "/bin/gaiad";
-          };
-          gaia6_0_3 = mkApp {
-            name = "gaia";
-            drv = packages.gaia6_0_3;
-            exePath = "/bin/gaiad";
-          };
-          gaia6_0_4 = mkApp {
-            name = "gaia";
-            drv = packages.gaia6_0_4;
+            drv = packages.gaia6;
             exePath = "/bin/gaiad";
           };
           gaia6-ordered = mkApp {

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -16,27 +16,11 @@ in
         tags = ["netgo"];
       };
 
-      gaia6_0_2 = {
-        name = "gaia";
-        vendorSha256 = "sha256-CNxWgIWf+8wB2CAUk+WadnIb3fi1UYftPea5sWtk/Rs=";
-        version = "v6.0.2";
-        src = gaia6_0_2-src;
-        tags = ["netgo"];
-      };
-
-      gaia6_0_3 = {
-        name = "gaia";
-        vendorSha256 = "sha256-cNQOv4wW98Vd08ieU3jgsvXoSDQQYZTkeTqUD2Cty58=";
-        version = "v6.0.3";
-        src = gaia6_0_3-src;
-        tags = ["netgo"];
-      };
-
-      gaia6_0_4 = {
+      gaia6 = {
         name = "gaia";
         vendorSha256 = "sha256-KeF3gO5sUJEXWqb6EVYBYXpVBfhvyXZ4f03l63wYTjE=";
         version = "v6.0.4";
-        src = gaia6_0_4-src;
+        src = gaia6-src;
         tags = ["netgo"];
       };
 
@@ -48,11 +32,9 @@ in
         tags = ["netgo"];
       };
 
-      gaia6 = gaia6_0_4;
-
       gaia7 = {
         name = "gaia";
-        vendorSha256 = "sha256-fGRLYkxZDowkuHcX26aRclLind0PRKkC64CQBVrnBr8=";
+        vendorSha256 = "sha256-OLo/pQNqYguQXeOyUgEMeghjiBq2Tp0JrOz52uy+e/A=";
         version = "v7.0.0";
         src = gaia7-src;
         tags = ["netgo"];

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -24,11 +24,11 @@ in
         tags = ["netgo"];
       };
 
-      ibc-go-ics29-simapp = {
+      ibc-go-main-simapp = {
         name = "simapp";
-        version = "v6.0.0-ics29";
-        src = ibc-go-ics29-src;
-        vendorSha256 = "sha256-e2aA/mme24hi3ERl/ooZc1YsshlvHmXak/VEwGe5Q3I=";
+        version = "v7.0.0-main";
+        src = ibc-go-main-src;
+        vendorSha256 = "sha256-2RBZNUIZVdPPI63FzkmOOPSlYlFE+UjzMMnqKEjayNY=";
         tags = ["netgo"];
       };
     }

--- a/tests.nix
+++ b/tests.nix
@@ -9,10 +9,10 @@ else {
   hermes-module-test = (import ./modules/tests/hermes-test.nix) {
     inherit (packages) hermes;
     inherit pkgs;
-    gaia = packages.gaia6_0_3;
+    gaia = packages.gaia7;
   };
   gaia-module-test = (import ./modules/tests/gaia-test.nix) {
     inherit pkgs;
-    gaia = packages.gaia6_0_3;
+    gaia = packages.gaia7;
   };
 }


### PR DESCRIPTION
- Update `gaia7` to `v7.0.1`
- Update `ibc-go-ics29-simapp` to `ibc-go-main-simapp`, as ICS29 has been merged into the `main` branch but not yet released.
- Remove the subversions `gaia6_0_2` to `gaia6_0_4`, and keep only `gaia6`, as the critical bugs in Gaia v6 has been resolved in v6.0.4.