### PR TITLE
Add back `ibc-go-ics29-simapp`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,14 +183,31 @@
         "type": "github"
       }
     },
+    "ibc-go-ics29-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1652196479,
+        "narHash": "sha256-kdSJwSIA2MvPFLguvCPe6TnzMkmQI3pIVJNhN/B7gwU=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "dcd0681d8f07c624f53b9a9ffe9de2f122486207",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "ics29-beta2",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1651571071,
-        "narHash": "sha256-AwTTN6p5/Q5tnoipuylv1qF8Gw4I7YHASLvIwtLxvLA=",
+        "lastModified": 1652196479,
+        "narHash": "sha256-kdSJwSIA2MvPFLguvCPe6TnzMkmQI3pIVJNhN/B7gwU=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "bd086506f9256c4d5776bc38d2e930b523eb5125",
+        "rev": "dcd0681d8f07c624f53b9a9ffe9de2f122486207",
         "type": "github"
       },
       "original": {
@@ -435,6 +452,7 @@
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",
         "gaia7-src": "gaia7-src",
+        "ibc-go-ics29-src": "ibc-go-ics29-src",
         "ibc-go-main-src": "ibc-go-main-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",

--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652196479,
-        "narHash": "sha256-kdSJwSIA2MvPFLguvCPe6TnzMkmQI3pIVJNhN/B7gwU=",
+        "lastModified": 1655117979,
+        "narHash": "sha256-9Ic4Rv2xco+5dzRDJ4wvq8AFnzIPfl5MAZaBWW9JjbE=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "dcd0681d8f07c624f53b9a9ffe9de2f122486207",
+        "rev": "11297aaa61e651c16e6d4147a15be24ce55ba7cc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -203,16 +203,17 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1657010958,
-        "narHash": "sha256-N+f1EeX6qJVBJXpJISlpqgerNJuapYG7MaDJqZt5tCM=",
+        "lastModified": 1656708313,
+        "narHash": "sha256-5g863fjt+4cZrvPwOPXe7odRp8l/NvqJ2/Gij9gfrbg=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "7d181821314d4bc6d0f8a5b885f293f5b975aed0",
+        "rev": "6c4a44243e6a381293920aab483c44aa840cf556",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
+        "rev": "6c4a44243e6a381293920aab483c44aa840cf556",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655117979,
-        "narHash": "sha256-9Ic4Rv2xco+5dzRDJ4wvq8AFnzIPfl5MAZaBWW9JjbE=",
+        "lastModified": 1655287744,
+        "narHash": "sha256-7HuNg2h2I2mYO/dql1P4aHfuFn/WlqhlA3kQ4upqKrw=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "11297aaa61e651c16e6d4147a15be24ce55ba7cc",
+        "rev": "a71fc1029ad1fc6d377d642781d02ad3cbfa0910",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -183,23 +183,6 @@
         "type": "github"
       }
     },
-    "ibc-go-ics29-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1655712472,
-        "narHash": "sha256-1KoCoWezR+A+rwy2U77kZrmckcwtOc2brfpiksUHmOk=",
-        "owner": "cosmos",
-        "repo": "ibc-go",
-        "rev": "6c034bc085e1701a7cbaa26476eb33e958b3a57c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmos",
-        "ref": "ics29-beta3",
-        "repo": "ibc-go",
-        "type": "github"
-      }
-    },
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
@@ -469,7 +452,6 @@
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",
         "gaia7-src": "gaia7-src",
-        "ibc-go-ics29-src": "ibc-go-ics29-src",
         "ibc-go-main-src": "ibc-go-main-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",

--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655287744,
-        "narHash": "sha256-7HuNg2h2I2mYO/dql1P4aHfuFn/WlqhlA3kQ4upqKrw=",
+        "lastModified": 1656015845,
+        "narHash": "sha256-5y+7CrbXW7Gy6IzLavd/b1jWWQemrjXxcpAnSc2JLzI=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "a71fc1029ad1fc6d377d642781d02ad3cbfa0910",
+        "rev": "20ffa6f1aca8adddccdcd714488eead2256a420d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -186,16 +186,16 @@
     "ibc-go-ics29-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652196479,
-        "narHash": "sha256-kdSJwSIA2MvPFLguvCPe6TnzMkmQI3pIVJNhN/B7gwU=",
+        "lastModified": 1655712472,
+        "narHash": "sha256-1KoCoWezR+A+rwy2U77kZrmckcwtOc2brfpiksUHmOk=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "dcd0681d8f07c624f53b9a9ffe9de2f122486207",
+        "rev": "6c034bc085e1701a7cbaa26476eb33e958b3a57c",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "ics29-beta2",
+        "ref": "ics29-beta3",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -203,11 +203,11 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1656015845,
-        "narHash": "sha256-5y+7CrbXW7Gy6IzLavd/b1jWWQemrjXxcpAnSc2JLzI=",
+        "lastModified": 1657010958,
+        "narHash": "sha256-N+f1EeX6qJVBJXpJISlpqgerNJuapYG7MaDJqZt5tCM=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "20ffa6f1aca8adddccdcd714488eead2256a420d",
+        "rev": "7d181821314d4bc6d0f8a5b885f293f5b975aed0",
         "type": "github"
       },
       "original": {
@@ -236,16 +236,33 @@
     "ibc-go-v3-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647356202,
-        "narHash": "sha256-wX3kUzK5dkPeNgmBGP0mE8QeNR4LRo1obVGasZSLSpE=",
+        "lastModified": 1655212180,
+        "narHash": "sha256-68YXAToz6p5cmiFEkdfMmcAsOb8EnLYLls5695V94CY=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "46e020640e66f9043c14c53a4d215a5b457d6703",
+        "rev": "bf062ad92329a659b3b20122b7c3bc5823c040e1",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v3.0.0",
+        "ref": "v3.1.0",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
+    "ibc-go-v4-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656924495,
+        "narHash": "sha256-WeIpJOgLO3hNbSfkrnzRcXE3NrBago9nhdtT2XDDXKA=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "efda07d984a65ad4099fc6d9c82f71a28d66a411",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "v4.0.0-rc0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -456,6 +473,7 @@
         "ibc-go-main-src": "ibc-go-main-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",
+        "ibc-go-v4-src": "ibc-go-v4-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",
         "iris-src": "iris-src",

--- a/flake.lock
+++ b/flake.lock
@@ -203,17 +203,16 @@
     "ibc-go-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1656708313,
-        "narHash": "sha256-5g863fjt+4cZrvPwOPXe7odRp8l/NvqJ2/Gij9gfrbg=",
+        "lastModified": 1657010958,
+        "narHash": "sha256-N+f1EeX6qJVBJXpJISlpqgerNJuapYG7MaDJqZt5tCM=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "6c4a44243e6a381293920aab483c44aa840cf556",
+        "rev": "7d181821314d4bc6d0f8a5b885f293f5b975aed0",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "6c4a44243e6a381293920aab483c44aa840cf556",
         "type": "github"
       }
     },
@@ -354,11 +353,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1657056915,
+        "narHash": "sha256-pzpuGI0+UHNlWae91QYeAlK0rY0FGZJAhHfRArHNwKY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "c9ad20e7ebbe27a29d12353d15cdc853f896291b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
     ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta3;
 
     ibc-go-main-src.flake = false;
-    ibc-go-main-src.url = github:cosmos/ibc-go/6c4a44243e6a381293920aab483c44aa840cf556;
+    ibc-go-main-src.url = github:cosmos/ibc-go;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.45.0-rc1;

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,13 @@
     ibc-go-v2-src.url = github:cosmos/ibc-go/v2.2.0;
 
     ibc-go-v3-src.flake = false;
-    ibc-go-v3-src.url = github:cosmos/ibc-go/v3.0.0;
+    ibc-go-v3-src.url = github:cosmos/ibc-go/v3.1.0;
+
+    ibc-go-v4-src.flake = false;
+    ibc-go-v4-src.url = github:cosmos/ibc-go/v4.0.0-rc0;
 
     ibc-go-ics29-src.flake = false;
-    ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta2;
+    ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta3;
 
     ibc-go-main-src.flake = false;
     ibc-go-main-src.url = github:cosmos/ibc-go;

--- a/flake.nix
+++ b/flake.nix
@@ -56,9 +56,6 @@
     ibc-go-v4-src.flake = false;
     ibc-go-v4-src.url = github:cosmos/ibc-go/v4.0.0-rc0;
 
-    ibc-go-ics29-src.flake = false;
-    ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta3;
-
     ibc-go-main-src.flake = false;
     ibc-go-main-src.url = github:cosmos/ibc-go;
 

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
     ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta3;
 
     ibc-go-main-src.flake = false;
-    ibc-go-main-src.url = github:cosmos/ibc-go;
+    ibc-go-main-src.url = github:cosmos/ibc-go/6c4a44243e6a381293920aab483c44aa840cf556;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.45.0-rc1;

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
     ibc-go-v3-src.flake = false;
     ibc-go-v3-src.url = github:cosmos/ibc-go/v3.0.0;
 
+    ibc-go-ics29-src.flake = false;
+    ibc-go-ics29-src.url = github:cosmos/ibc-go/ics29-beta2;
+
     ibc-go-main-src.flake = false;
     ibc-go-main-src.url = github:cosmos/ibc-go;
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -39,12 +39,4 @@ in
         vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
         tags = ["netgo"];
       };
-
-      ibc-go-ics29-simapp = {
-        name = "simapp";
-        version = "v4.0.0-ics29-beta3";
-        src = ibc-go-ics29-src;
-        vendorSha256 = "sha256-Fxdi71yKS00xTrmRCKOS/7uoULif4OGhbUqd0NSAjZM=";
-        tags = ["netgo"];
-      };
     }

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -31,4 +31,12 @@ in
         vendorSha256 = "sha256-2RBZNUIZVdPPI63FzkmOOPSlYlFE+UjzMMnqKEjayNY=";
         tags = ["netgo"];
       };
+
+      ibc-go-ics29-simapp = {
+        name = "simapp";
+        version = "v7.0.0-ics29-beta2";
+        src = ibc-go-ics29-src;
+        vendorSha256 = "sha256-2RBZNUIZVdPPI63FzkmOOPSlYlFE+UjzMMnqKEjayNY=";
+        tags = ["netgo"];
+      };
     }

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -28,7 +28,7 @@ in
         name = "simapp";
         version = "v7.0.0-main";
         src = ibc-go-main-src;
-        vendorSha256 = "sha256-2RBZNUIZVdPPI63FzkmOOPSlYlFE+UjzMMnqKEjayNY=";
+        vendorSha256 = "sha256-nkL4aJuu459yg60yfCexMrt13P18pmaRrHmM12JVfig=";
         tags = ["netgo"];
       };
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -36,7 +36,7 @@ in
         name = "simapp";
         version = "v4.0.0-main";
         src = ibc-go-main-src;
-        vendorSha256 = "sha256-NvU3GmfAxkWCaV7UN3IjV86f0G+5mEHmASnxbEaC/dw=";
+        vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
         tags = ["netgo"];
       };
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -28,7 +28,7 @@ in
         name = "simapp";
         version = "v7.0.0-main";
         src = ibc-go-main-src;
-        vendorSha256 = "sha256-nkL4aJuu459yg60yfCexMrt13P18pmaRrHmM12JVfig=";
+        vendorSha256 = "sha256-PkMF36VY85zueSc0uWJ40TlvcLE1NjL4Xojk7gQEM84=";
         tags = ["netgo"];
       };
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -36,7 +36,7 @@ in
         name = "simapp";
         version = "v4.0.0-main";
         src = ibc-go-main-src;
-        vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
+        vendorSha256 = "sha256-NvU3GmfAxkWCaV7UN3IjV86f0G+5mEHmASnxbEaC/dw=";
         tags = ["netgo"];
       };
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -27,8 +27,8 @@ in
       ibc-go-v4-simapp = {
         name = "simapp";
         version = "v4.0.0";
-        src = ibc-go-v3-src;
-        vendorSha256 = "sha256-kefoBLr1pbyycUjel6rZ8VsqCLbPFY5hUHUVyO+Y2wc=";
+        src = ibc-go-v4-src;
+        vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
         tags = ["netgo"];
       };
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -11,32 +11,40 @@ in
       ibc-go-v2-simapp = {
         name = "simapp";
         src = ibc-go-v2-src;
-        version = "v6.0.0-v3";
+        version = "v2.0.0";
         vendorSha256 = "sha256-Af47uEEPCFsX1JiMiw3LprGDiVb/0HA0sMeuDdAVXu8=";
         tags = ["netgo"];
       };
 
       ibc-go-v3-simapp = {
         name = "simapp";
-        version = "v6.0.0-v3";
+        version = "v3.0.0";
         src = ibc-go-v3-src;
-        vendorSha256 = "sha256-W05fH/y7InNgY68aJLlm32c8DpAKFnO3ehH8CzzYdPI=";
+        vendorSha256 = "sha256-kefoBLr1pbyycUjel6rZ8VsqCLbPFY5hUHUVyO+Y2wc=";
+        tags = ["netgo"];
+      };
+
+      ibc-go-v4-simapp = {
+        name = "simapp";
+        version = "v4.0.0";
+        src = ibc-go-v3-src;
+        vendorSha256 = "sha256-kefoBLr1pbyycUjel6rZ8VsqCLbPFY5hUHUVyO+Y2wc=";
         tags = ["netgo"];
       };
 
       ibc-go-main-simapp = {
         name = "simapp";
-        version = "v7.0.0-main";
+        version = "v4.0.0-main";
         src = ibc-go-main-src;
-        vendorSha256 = "sha256-PkMF36VY85zueSc0uWJ40TlvcLE1NjL4Xojk7gQEM84=";
+        vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
         tags = ["netgo"];
       };
 
       ibc-go-ics29-simapp = {
         name = "simapp";
-        version = "v7.0.0-ics29-beta2";
+        version = "v4.0.0-ics29-beta3";
         src = ibc-go-ics29-src;
-        vendorSha256 = "sha256-2RBZNUIZVdPPI63FzkmOOPSlYlFE+UjzMMnqKEjayNY=";
+        vendorSha256 = "sha256-Fxdi71yKS00xTrmRCKOS/7uoULif4OGhbUqd0NSAjZM=";
         tags = ["netgo"];
       };
     }

--- a/resources/utilities.nix
+++ b/resources/utilities.nix
@@ -18,7 +18,7 @@
       then "${name}d"
       else appName;
   in
-    pkgs.buildGoModule ({
+    pkgs.buildGo118Module ({
         inherit version src vendorSha256;
         pname = name;
         preCheck =


### PR DESCRIPTION
This PR adds back the `ibc-go-ics29-simapp` that tracks the [beta branch for ICS29](https://github.com/cosmos/ibc-go/tree/ics29-beta2) for ibc-go. There is no need to merge this to `main`, as ICS29 has not been officially released.

This also updates the main branch for `ibc-go-main-simapp`.