### PR TITLE
Add pre-release version of Gaia Rho

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,6 +115,23 @@
         "type": "github"
       }
     },
+    "gaia-rho-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1652962673,
+        "narHash": "sha256-m9bSBLvpOA07USV8ecTx7a3Odfauyo3u2m4VLz1t7c0=",
+        "owner": "cosmos",
+        "repo": "gaia",
+        "rev": "7394d2bb89c72a40da35bf2322709c73375de780",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "rho-ibc",
+        "repo": "gaia",
+        "type": "github"
+      }
+    },
     "gaia5-src": {
       "flake": false,
       "locked": {
@@ -431,6 +448,7 @@
         "crescent-src": "crescent-src",
         "evmos-src": "evmos-src",
         "flake-utils": "flake-utils",
+        "gaia-rho-src": "gaia-rho-src",
         "gaia5-src": "gaia5-src",
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,9 @@
     gaia5-src.flake = false;
     gaia5-src.url = github:cosmos/gaia/v5.0.8;
 
+    gaia-rho-src.flake = false;
+    gaia-rho-src.url = github:cosmos/gaia/rho-ibc;
+
     ibc-go-v2-src.flake = false;
     ibc-go-v2-src.url = github:cosmos/ibc-go/v2.2.0;
 

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -42,4 +42,15 @@ in
         # Tests have to be disabled because they require Docker to run
         doCheck = false;
       };
+
+      gaia-rho = {
+        name = "gaia";
+        vendorSha256 = "sha256-YWR8Pp5uJ+a5giV4xfpt5iqMbsIBRujVz4YHBc2pLSI=";
+        version = "v8.0.0";
+        src = gaia-rho-src;
+        tags = ["netgo"];
+
+        # Tests have to be disabled because they require Docker to run
+        doCheck = false;
+      };
     }


### PR DESCRIPTION
This is a draft PR to track the Gaia branch at [gaia/rho-ibc](https://github.com/cosmos/gaia/tree/rho-ibc).

This version of Gaia can be loaded with:

```bash
nix shell github:informalsystems/cosmos.nix/gaia-rho#gaia-rho
```