### PR TITLE
Update core Cosmos packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     "cosmos-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1642008757,
-        "narHash": "sha256-owsXBdYIf7yENDjumqyQ5AQ+jPHKxVbpQbApUpTzoxo=",
+        "lastModified": 1658846655,
+        "narHash": "sha256-Xs83vbgt4+YH2LRJx7692nIjRBr5QCYoUHI17njsjlw=",
         "owner": "cosmos",
         "repo": "cosmos-sdk",
-        "rev": "c1c1ad7425292924b77dc632370815088b2d3c58",
+        "rev": "a1143138716b64bc4fa0aa53c0f0fa59eb675bb7",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v0.45.0-rc1",
+        "ref": "v0.46.0",
         "repo": "cosmos-sdk",
         "type": "github"
       }
@@ -169,49 +169,33 @@
     "gaia7-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1649856981,
-        "narHash": "sha256-SQCKRnf56uNZp/TCJAkDdHTQNbHJNZXu6BmhXqtNvvs=",
+        "lastModified": 1659460265,
+        "narHash": "sha256-rCqt18n2XoFZQ0yXYZZhQ9I7OTMA2HuPp6rGFZlFbqI=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "0664d9ec7c7acbcd944174f2f5326a7df5654bdf",
+        "rev": "d0884c29aac4c1e647b0a82f3df31515d2bd06a3",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.0.1",
+        "ref": "v7.0.3",
         "repo": "gaia",
-        "type": "github"
-      }
-    },
-    "ibc-go-main-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1657010958,
-        "narHash": "sha256-N+f1EeX6qJVBJXpJISlpqgerNJuapYG7MaDJqZt5tCM=",
-        "owner": "cosmos",
-        "repo": "ibc-go",
-        "rev": "7d181821314d4bc6d0f8a5b885f293f5b975aed0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmos",
-        "repo": "ibc-go",
         "type": "github"
       }
     },
     "ibc-go-v2-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647351578,
-        "narHash": "sha256-n2xo3CGyO9wgIPvHgKqDfPjhhy3eHNGX6XDn707BTwk=",
+        "lastModified": 1659443514,
+        "narHash": "sha256-U7eaZLmQ7VTFb2SasxUXUDsYxut+8sf1cPy0cvYNr2o=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "bfb76858a34489d85c0404e4fdd597389229787d",
+        "rev": "0aec7cefccf320e5ab26213158ecdbce33705b21",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v2.2.0",
+        "ref": "v2.3.1",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -219,16 +203,16 @@
     "ibc-go-v3-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655212180,
-        "narHash": "sha256-68YXAToz6p5cmiFEkdfMmcAsOb8EnLYLls5695V94CY=",
+        "lastModified": 1659443482,
+        "narHash": "sha256-YmdIe1M9Q/L8RGixWzrCgEkLQku3pcSYHeypCcVzqz4=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "bf062ad92329a659b3b20122b7c3bc5823c040e1",
+        "rev": "28b925ec30c9aceb9f05ce1f2ef5153364d98e6c",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v3.1.0",
+        "ref": "v3.1.1",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -236,16 +220,33 @@
     "ibc-go-v4-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1656924495,
-        "narHash": "sha256-WeIpJOgLO3hNbSfkrnzRcXE3NrBago9nhdtT2XDDXKA=",
+        "lastModified": 1659099948,
+        "narHash": "sha256-tAVxGURtizHinscQkW38uW4IFWqs7DLwGkEywKuglq8=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "efda07d984a65ad4099fc6d9c82f71a28d66a411",
+        "rev": "bc534e94441319aae93bdccef531d066d9aececb",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v4.0.0-rc0",
+        "ref": "v4.0.0-rc2",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
+    "ibc-go-v5-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659384529,
+        "narHash": "sha256-tMV4Aesa9IY6TXxpLo9aIsRFKJDVSIlZqR8OlWP9/3g=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "662a9a82735e1928ec914058589fe0f36b0283ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "v5.0.0-beta1",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -336,11 +337,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657056915,
-        "narHash": "sha256-pzpuGI0+UHNlWae91QYeAlK0rY0FGZJAhHfRArHNwKY=",
+        "lastModified": 1659464610,
+        "narHash": "sha256-X67Sbnn4lbo+RFWDjlG9oJsSWE6zg4S+LuQ5TLB2lCo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c9ad20e7ebbe27a29d12353d15cdc853f896291b",
+        "rev": "f310f24f0d4cd5e8660ccde49e8cbd8dbf0295fa",
         "type": "github"
       },
       "original": {
@@ -452,10 +453,10 @@
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",
         "gaia7-src": "gaia7-src",
-        "ibc-go-main-src": "ibc-go-main-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",
         "ibc-go-v4-src": "ibc-go-v4-src",
+        "ibc-go-v5-src": "ibc-go-v5-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",
         "iris-src": "iris-src",

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
     # Chain Sources
     gaia7-src.flake = false;
-    gaia7-src.url = github:cosmos/gaia/v7.0.1;
+    gaia7-src.url = github:cosmos/gaia/v7.0.3;
 
     gaia6-ordered-src.flake = false;
     gaia6-ordered-src.url = github:informalsystems/gaia/v6.0.4-ordered;
@@ -48,19 +48,19 @@
     gaia5-src.url = github:cosmos/gaia/v5.0.8;
 
     ibc-go-v2-src.flake = false;
-    ibc-go-v2-src.url = github:cosmos/ibc-go/v2.2.0;
+    ibc-go-v2-src.url = github:cosmos/ibc-go/v2.3.1;
 
     ibc-go-v3-src.flake = false;
-    ibc-go-v3-src.url = github:cosmos/ibc-go/v3.1.0;
+    ibc-go-v3-src.url = github:cosmos/ibc-go/v3.1.1;
 
     ibc-go-v4-src.flake = false;
-    ibc-go-v4-src.url = github:cosmos/ibc-go/v4.0.0-rc0;
+    ibc-go-v4-src.url = github:cosmos/ibc-go/v4.0.0-rc2;
 
-    ibc-go-main-src.flake = false;
-    ibc-go-main-src.url = github:cosmos/ibc-go;
+    ibc-go-v5-src.flake = false;
+    ibc-go-v5-src.url = github:cosmos/ibc-go/v5.0.0-beta1;
 
     cosmos-sdk-src.flake = false;
-    cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.45.0-rc1;
+    cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;
 
     iris-src.flake = false;
     iris-src.url = github:irisnet/irishub/v1.1.1;

--- a/resources.nix
+++ b/resources.nix
@@ -45,14 +45,14 @@
       cosmovisor = pkgs.buildGoModule {
         name = "cosmovisor";
         src = "${inputs.cosmos-sdk-src}/cosmovisor";
-        vendorSha256 = "sha256-OAXWrwpartjgSP7oeNvDJ7cTR9lyYVNhEM8HUnv3acE=";
+        vendorSha256 = "sha256-APJ+mt8e2zHiO/8UI7Zt63P5HFxEG2ogLf5uxfp58cQ=";
         doCheck = false;
       };
 
       simd = pkgs.buildGoModule {
         name = "simd";
         src = cleanSourceWithRegexes inputs.cosmos-sdk-src [".*cosmovisor.*"];
-        vendorSha256 = "sha256-kYoGoNT9W7x8iVjXyMCe72TCeq1RNILw53SmNpv/VXg=";
+        vendorSha256 = "sha256-ZlfvpnaF/SBHeXW2tzO3DVEyh1Uh4qNNXBd+AoWd/go=";
         doCheck = false;
       };
 

--- a/resources.nix
+++ b/resources.nix
@@ -4,17 +4,6 @@
   pkgs,
   eval-pkgs,
 }: let
-  cleanSourceWithRegexes = src: regexes:
-    with pkgs.lib;
-    with builtins;
-      cleanSourceWith {
-        filter = (
-          path: _:
-            all (r: match r path == null) regexes
-        );
-        inherit src;
-      };
-
   gaia-packages = import ./resources/gaia {
     inherit pkgs inputs;
   };
@@ -51,9 +40,12 @@
 
       simd = pkgs.buildGoModule {
         name = "simd";
-        src = cleanSourceWithRegexes inputs.cosmos-sdk-src [".*cosmovisor.*"];
+        src = inputs.cosmos-sdk-src;
         vendorSha256 = "sha256-ZlfvpnaF/SBHeXW2tzO3DVEyh1Uh4qNNXBd+AoWd/go=";
         doCheck = false;
+        patchPhase = ''
+          rm -r client/v2 cosmovisor container core db errors math orm store/tools
+        '';
       };
 
       regen = utilities.mkCosmosGoApp {

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -34,8 +34,8 @@ in
 
       gaia7 = {
         name = "gaia";
-        vendorSha256 = "sha256-OLo/pQNqYguQXeOyUgEMeghjiBq2Tp0JrOz52uy+e/A=";
-        version = "v7.0.0";
+        vendorSha256 = "sha256-rohPqCjPC3yr8wDNpndbhP6t7AgjY+kyqRGJYApCMgs=";
+        version = "v7.0.3";
         src = gaia7-src;
         tags = ["netgo"];
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -11,16 +11,16 @@ in
       ibc-go-v2-simapp = {
         name = "simapp";
         src = ibc-go-v2-src;
-        version = "v2.0.0";
-        vendorSha256 = "sha256-Af47uEEPCFsX1JiMiw3LprGDiVb/0HA0sMeuDdAVXu8=";
+        version = "v2.3.1";
+        vendorSha256 = "sha256-B1ZAnE62cqRte0hvSCWtsc5zD5moeN8x/beLgBhpvIw=";
         tags = ["netgo"];
       };
 
       ibc-go-v3-simapp = {
         name = "simapp";
-        version = "v3.0.0";
+        version = "v3.1.1";
         src = ibc-go-v3-src;
-        vendorSha256 = "sha256-kefoBLr1pbyycUjel6rZ8VsqCLbPFY5hUHUVyO+Y2wc=";
+        vendorSha256 = "sha256-jN2qO+jmCouc5/s/yx4hhfKZkvZuK/ii6j+Hvxfh7sM=";
         tags = ["netgo"];
       };
 
@@ -32,11 +32,14 @@ in
         tags = ["netgo"];
       };
 
-      ibc-go-main-simapp = {
+      ibc-go-v5-simapp = {
         name = "simapp";
-        version = "v4.0.0-main";
-        src = ibc-go-main-src;
-        vendorSha256 = "sha256-7NJoasvGMUtJqZpqLDm6+aVrKQw3VYO/13udb8wKz5s=";
+        version = "v5.0.0";
+        src = ibc-go-v5-src;
+        vendorSha256 = "sha256-vPkvYrdk5yOC/imtDobHSFWSXmvT7vfHpe0WGoxZ490=";
         tags = ["netgo"];
+        patchPhase = ''
+          rm -r e2e
+        '';
       };
     }

--- a/resources/utilities.nix
+++ b/resources/utilities.nix
@@ -9,9 +9,6 @@
     preCheck ? null,
     ...
   } @ args: let
-    parser = import ./goModParser.nix;
-    go-mod = parser (builtins.readFile "${src}/go.mod");
-    tendermint-version = go-mod.require."github.com/tendermint/tendermint".version;
     buildGoModuleArgs = pkgs.lib.filterAttrs (n: _: builtins.all (a: a != n) ["src" "name" "version" "vendorSha256" "appName"]) args;
     ldFlagAppName =
       if appName == null
@@ -30,7 +27,6 @@
           -X github.com/cosmos/cosmos-sdk/version.AppName=${ldFlagAppName}
           -X github.com/cosmos/cosmos-sdk/version.Version=${version}
           -X github.com/cosmos/cosmos-sdk/version.Commit=${src.rev}
-          -X github.com/tendermint/tendermint/version.TMCoreSemVer=${tendermint-version}
           ${additionalLdFlags}
         '';
       }


### PR DESCRIPTION
Updated the following packages:

- `gaia7` to `v7.0.3`
- `ibc-go-v2-simapp` to `v2.3.1`
- `ibc-go-v3-simapp` to `v3.1.1`
- `ibc-go-v4-simapp` to `v4.0.0-rc2`
- `cosmos-sdk` to `v0.46.0`

Also added:
- `ibc-go-v5-simapp` at `v5.0.0-beta1`