### PR TITLE
Add Gaia v8.0.0-rc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -199,6 +199,23 @@
         "type": "github"
       }
     },
+    "gaia8-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667411611,
+        "narHash": "sha256-DlFLKskYPC7rj55MeD9LTDTnuV8oadxGT4JVzRs2GyU=",
+        "owner": "cosmos",
+        "repo": "gaia",
+        "rev": "8ef100554881240de6698449dc6f1bc9c1d5b771",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "v8.0.0-rc",
+        "repo": "gaia",
+        "type": "github"
+      }
+    },
     "ibc-go-v2-src": {
       "flake": false,
       "locked": {
@@ -587,6 +604,7 @@
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",
         "gaia7-src": "gaia7-src",
+        "gaia8-src": "gaia8-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",
         "ibc-go-v4-src": "ibc-go-v4-src",

--- a/flake.lock
+++ b/flake.lock
@@ -253,16 +253,16 @@
     "ibc-go-v4-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1663683227,
-        "narHash": "sha256-+7qCyWKsDg0R/zoj++IuLGdG1C4n6Q9C4RcLMqlwV5A=",
+        "lastModified": 1667809128,
+        "narHash": "sha256-R1/AH6laXdaMftgwnV4t/pL3QoKnZ1UaBGoqOipOvQI=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "197555e7b879032cdbda32d1dba60b6164f9a0f6",
+        "rev": "ecb845d5e43f53decf48f8ed88c7847a9a4375cb",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v4.1.0",
+        "ref": "v4.2.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -270,16 +270,16 @@
     "ibc-go-v5-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1664375342,
-        "narHash": "sha256-FrMSigZVRkwv66pWW85GZTYcsnITRl3ERptaoN4W1oA=",
+        "lastModified": 1668024626,
+        "narHash": "sha256-+Z78PyGODLr2Y5G8evubsoQE3tyUcxCHJDsLXKTmdlI=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "ed56c0b7bf64f44fb9e87ad2756bea1d6ca6ce54",
+        "rev": "c0acd5bd1778f2b7ecdf593006f56bd3e273bd49",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v5.0.0",
+        "ref": "v5.1.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -287,16 +287,16 @@
     "ibc-go-v6-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1664530583,
-        "narHash": "sha256-COUx/eEmrXBfyisMF/32Vi89DzqGxIkVkWm5AZWlZWk=",
+        "lastModified": 1668246281,
+        "narHash": "sha256-H1HEXtNBIYaMdd5JohPYOCkn6DWrlRoqCllYbVg4oMk=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "ad7fb5dbfceaf336887ab3857b7858df73eb3be7",
+        "rev": "6415cc4f402b23bf44b459f30d64b838b084b160",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v6.0.0-alpha1",
+        "ref": "v6.0.0-rc0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -185,16 +185,16 @@
     "gaia7-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1659460265,
-        "narHash": "sha256-rCqt18n2XoFZQ0yXYZZhQ9I7OTMA2HuPp6rGFZlFbqI=",
+        "lastModified": 1665762684,
+        "narHash": "sha256-hsDqDASwTPIb1BGOqa9nu4C5Y5q3hBoXYhkAFY7B9Cs=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "d0884c29aac4c1e647b0a82f3df31515d2bd06a3",
+        "rev": "5db8fcc9a229730f5115bed82d0f85b6db7184b4",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.0.3",
+        "ref": "v7.1.0",
         "repo": "gaia",
         "type": "github"
       }
@@ -436,11 +436,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659464610,
-        "narHash": "sha256-X67Sbnn4lbo+RFWDjlG9oJsSWE6zg4S+LuQ5TLB2lCo=",
+        "lastModified": 1669076005,
+        "narHash": "sha256-uzMji2q9Pk3jUH+e5nEFtoOZCP4VV1PDRJRLVmriY0M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f310f24f0d4cd5e8660ccde49e8cbd8dbf0295fa",
+        "rev": "69335c46c48a73f291d5c6f332fb9fe8b8e22b30",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,9 @@
     gaia-main-src.flake = false;
     gaia-main-src.url = github:cosmos/gaia;
 
+    gaia8-src.flake = false;
+    gaia8-src.url = github:cosmos/gaia/v8.0.0-rc;
+
     gaia7-src.flake = false;
     gaia7-src.url = github:cosmos/gaia/v7.0.3;
 
@@ -212,6 +215,11 @@
           gaia7 = mkApp {
             name = "gaia";
             drv = packages.gaia7;
+            exePath = "/bin/gaiad";
+          };
+          gaia8 = mkApp {
+            name = "gaia";
+            drv = packages.gaia8;
             exePath = "/bin/gaiad";
           };
           gaia-main = mkApp {

--- a/flake.nix
+++ b/flake.nix
@@ -62,13 +62,13 @@
     ibc-go-v3-src.url = github:cosmos/ibc-go/v3.3.0;
 
     ibc-go-v4-src.flake = false;
-    ibc-go-v4-src.url = github:cosmos/ibc-go/v4.1.0;
+    ibc-go-v4-src.url = github:cosmos/ibc-go/v4.2.0;
 
     ibc-go-v5-src.flake = false;
-    ibc-go-v5-src.url = github:cosmos/ibc-go/v5.0.0;
+    ibc-go-v5-src.url = github:cosmos/ibc-go/v5.1.0;
 
     ibc-go-v6-src.flake = false;
-    ibc-go-v6-src.url = github:cosmos/ibc-go/v6.0.0-alpha1;
+    ibc-go-v6-src.url = github:cosmos/ibc-go/v6.0.0-rc0;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
     gaia8-src.url = github:cosmos/gaia/v8.0.0-rc;
 
     gaia7-src.flake = false;
-    gaia7-src.url = github:cosmos/gaia/v7.0.3;
+    gaia7-src.url = github:cosmos/gaia/v7.1.0;
 
     gaia6-ordered-src.flake = false;
     gaia6-ordered-src.url = github:informalsystems/gaia/v6.0.4-ordered;

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -47,8 +47,8 @@ in
 
       gaia7 = {
         name = "gaia";
-        vendorSha256 = "sha256-rohPqCjPC3yr8wDNpndbhP6t7AgjY+kyqRGJYApCMgs=";
-        version = "v7.0.3";
+        vendorSha256 = "sha256-bNeSSZ1n1fEvO9ITGGJzsc+S2QE7EoB703mPHzrEqAg=";
+        version = "v7.1.0";
         src = gaia7-src;
         tags = ["netgo"];
 
@@ -58,10 +58,11 @@ in
 
       gaia8 = {
         name = "gaia";
-        vendorSha256 = "sha256-MfFCMZDMknbsPkLU9vkkLA9AO4hB8WwfjDv5yrsc3bo=";
+        vendorSha256 = "sha256-FBxb53B4cZH08VTy45i7IY2uWgOjCCkwJUNSI8ScGwM=";
         version = "v8.0.0-rc";
         src = gaia8-src;
         tags = ["netgo"];
+        proxyVendor = true;
 
         # Tests have to be disabled because they require Docker to run
         doCheck = false;

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -55,4 +55,15 @@ in
         # Tests have to be disabled because they require Docker to run
         doCheck = false;
       };
+
+      gaia8 = {
+        name = "gaia";
+        vendorSha256 = "sha256-MfFCMZDMknbsPkLU9vkkLA9AO4hB8WwfjDv5yrsc3bo=";
+        version = "v8.0.0-rc";
+        src = gaia8-src;
+        tags = ["netgo"];
+
+        # Tests have to be disabled because they require Docker to run
+        doCheck = false;
+      };
     }

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -31,17 +31,17 @@ in
 
       ibc-go-v4-simapp = {
         name = "simapp";
-        version = "v4.1.0";
+        version = "v4.2.0";
         src = ibc-go-v4-src;
-        vendorSha256 = "sha256-jI1Ky8SzwZ3PhAZrDJQknAWUnu0G9rktAyaE4J/o8Cw=";
+        vendorSha256 = "sha256-M8N6IPBnhOQp4LsCgdKc0NOtdeLNkAcXtGsvHS00D+g=";
         tags = ["netgo"];
       };
 
       ibc-go-v5-simapp = {
         name = "simapp";
-        version = "v5.0.0";
+        version = "v5.1.0";
         src = ibc-go-v5-src;
-        vendorSha256 = "sha256-hxffp0n0kchyUb6T4UzXqUZKGH4t4aHjuQhFQUjeUgA=";
+        vendorSha256 = "sha256-KajTi+hCMM8AoLsGmWV7qVGbYA8vZhn+0tmG20zJgPI=";
         tags = ["netgo"];
         excludedPackages = ["./e2e"];
       };
@@ -50,7 +50,7 @@ in
         name = "simapp";
         version = "v6.0.0";
         src = ibc-go-v6-src;
-        vendorSha256 = "sha256-hxffp0n0kchyUb6T4UzXqUZKGH4t4aHjuQhFQUjeUgA=";
+        vendorSha256 = "sha256-RrFwhpcraLBNdsYKNHAtsDDvGHZ7LsnDDj+B1ezepO8=";
         tags = ["netgo"];
         excludedPackages = ["./e2e"];
       };


### PR DESCRIPTION
The build of gaiad is failing, but I haven't been able to figure out how to fix it.

```
❯ nix shell '.#gaia8' 2>&1
this derivation will be built:
  /nix/store/96dm64dssdbxa75f1989qcvvj0hpg1c8-gaia-v8.0.0-rc.drv
building '/nix/store/96dm64dssdbxa75f1989qcvvj0hpg1c8-gaia-v8.0.0-rc.drv'...
error: builder for '/nix/store/96dm64dssdbxa75f1989qcvvj0hpg1c8-gaia-v8.0.0-rc.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking source archive /nix/store/ldambiicxmar8rsaapkq1i8vxrrplwam-source
       > source root is source
       > patching sources
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > building
       > Building subPackage ./ante
       > go: -mod may only be set to readonly when in workspace mode, but it is set to "vendor"
       >  Remove the -mod flag to use the default readonly value,
       >        or set GOWORK=off to disable workspace mode.
       For full logs, run 'nix log /nix/store/96dm64dssdbxa75f1989qcvvj0hpg1c8-gaia-v8.0.0-rc.drv'.
```

```
❯ nix log /nix/store/96dm64dssdbxa75f1989qcvvj0hpg1c8-gaia-v8.0.0-rc.drv
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/ldambiicxmar8rsaapkq1i8vxrrplwam-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Building subPackage ./ante
go: -mod may only be set to readonly when in workspace mode, but it is set to "vendor"
        Remove the -mod flag to use the default readonly value,
        or set GOWORK=off to disable workspace mode.
```

Might very well be a problem with my machine (Apple Silicon M2), since I am unable to build Gaia v8.0.0-rc by hand either:

```
❯ git branch
* (HEAD detached at v8.0.0-rc)
  main
```

```
❯ make build
go build -mod=readonly -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=gaia -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad -X github.com/cosmos/cosmos-sdk/version.Version=v8.0.0-rc -X github.com/cosmos/cosmos-sdk/version.Commit=8ef100554881240de6698449dc6f1bc9c1d5b771 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger" -X github.com/tendermint/tendermint/version.TMCoreSemVer=v0.34.22 -w -s' -trimpath -o /Users/romac/Informal/Code/gaia/build/ ./...
../../../.go/pkg/mod/github.com/cosmos/iavl@v0.19.3/fast_iterator.go:6:2: cannot find module providing package github.com/cosmos/cosmos-db: import lookup disabled by -mod=readonly
../../../.go/pkg/mod/github.com/cosmos/iavl@v0.19.3/proof_iavl_absence.go:6:2: cannot find module providing package github.com/cosmos/gogoproto/proto: import lookup disabled by -mod=readonly
make: *** [build] Error 1
```