### PR TITLE
Update Stride to v5.1.1 and add a patched Stride

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -838,16 +838,16 @@
     "stride-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1669073860,
-        "narHash": "sha256-3C1pmWVDFLuSofU27H58Y5bKloZh+EivW0T5ng7Y0IM=",
+        "lastModified": 1674783729,
+        "narHash": "sha256-hTrfuVzmuSAhBnKk24yV2u6yekpf4DzOfB9l4WHDLZg=",
         "owner": "Stride-Labs",
         "repo": "stride",
-        "rev": "613e85711485d3bebeeb5777ba35e701cc795a43",
+        "rev": "bf9dc8d6badcf97e6b9c01aa8bfc09516036db1e",
         "type": "github"
       },
       "original": {
         "owner": "Stride-Labs",
-        "ref": "v3.0.1",
+        "ref": "v5.1.1",
         "repo": "stride",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
     interchain-security-src.url = github:cosmos/interchain-security/v0.1.4;
 
     stride-src.flake = false;
-    stride-src.url = github:Stride-Labs/stride/v3.0.1;
+    stride-src.url = github:Stride-Labs/stride/v5.1.1;
   };
 
   outputs = inputs:
@@ -364,9 +364,9 @@
             drv = packages.apalache;
             exePath = "/bin/apalache-mc";
           };
-          stride3 = mkApp {
+          stride = mkApp {
             name = "stride";
-            drv = packages.stride3;
+            drv = packages.stride;
             exePath = "/bin/strided";
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -369,6 +369,11 @@
             drv = packages.stride;
             exePath = "/bin/strided";
           };
+          stride-no-admin = mkApp {
+            name = "stride-no-admin";
+            drv = packages.stride;
+            exePath = "/bin/strided";
+          };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -371,7 +371,7 @@
           };
           stride-no-admin = mkApp {
             name = "stride-no-admin";
-            drv = packages.stride;
+            drv = packages.stride-no-admin;
             exePath = "/bin/strided";
           };
         };

--- a/patches/stride-no-admin-check.patch
+++ b/patches/stride-no-admin-check.patch
@@ -1,0 +1,14 @@
+diff --git a/utils/utils.go b/utils/utils.go
+index 0f6642ef..d778a298 100644
+--- a/utils/utils.go
++++ b/utils/utils.go
+@@ -34,9 +34,6 @@ func Int64ToCoinString(amount int64, denom string) string {
+ }
+ 
+ func ValidateAdminAddress(address string) error {
+-	if !Admins[address] {
+-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, fmt.Sprintf("invalid creator address (%s)", address))
+-	}
+ 	return nil
+ }
+ 

--- a/resources.nix
+++ b/resources.nix
@@ -282,9 +282,19 @@
         name = "stride";
         version = "v5.1.1";
         src = inputs.stride-src;
-        vendorSha256 = "sha256-Hro3ns/Dq6Nv4rg4Vtk21HabTpT1Id5XywM4LFeKUIE=";
+        vendorSha256 = "sha256-3WdQKFxDk+bn76Q0F6JU2gGHTMBhaUaXX8sqQF+4DYg=";
+
+        doCheck = false;
+      };
+
+      stride-no-admin = utilities.mkCosmosGoApp {
+        name = "stride-no-admin";
+        version = "v5.1.1";
+        src = inputs.stride-src;
+        vendorSha256 = "sha256-3WdQKFxDk+bn76Q0F6JU2gGHTMBhaUaXX8sqQF+4DYg=";
 
         patches = [./patches/stride-no-admin-check.patch];
+        doCheck = false;
       };
 
       # Rust resources

--- a/resources.nix
+++ b/resources.nix
@@ -278,11 +278,11 @@
         buildInputs = [libwasmvm_1_1_1];
       };
 
-      strided = utilities.mkCosmosGoApp {
+      stride = utilities.mkCosmosGoApp {
         name = "stride";
-        version = "v3.0.1";
+        version = "v5.1.1";
         src = inputs.stride-src;
-        vendorSha256 = "sha256-Hro3nS/Dq6Nv4rg4Vtk21HabTpT1Id5XywM4LFeKUIE=";
+        vendorSha256 = "sha256-Hro3ns/Dq6Nv4rg4Vtk21HabTpT1Id5XywM4LFeKUIE=";
       };
 
       # Rust resources

--- a/resources.nix
+++ b/resources.nix
@@ -283,6 +283,8 @@
         version = "v5.1.1";
         src = inputs.stride-src;
         vendorSha256 = "sha256-Hro3ns/Dq6Nv4rg4Vtk21HabTpT1Id5XywM4LFeKUIE=";
+
+        patches = [./patches/stride-no-admin-check.patch];
       };
 
       # Rust resources


### PR DESCRIPTION
### Description

This PR updates the version of Stride to `v5.1.1` and adds a `#stride-no-admin` which doesn't have the `ValidateAdminAddress `

### Patched Stride

The patched Stride is required to run Hermes' ICS31 tests, https://github.com/informalsystems/hermes/pull/3061. More specifically it allows any account to call the CLI `strided tx stakeibc register-host-zone`.
Without the patch, Stride will return an invalid creator address error when a non-admin account is used to register a host zone.
Registering a host zone is required in order to have Stride trigger Cross Chain Queries.