### PR TITLE
Update simd to `v7.0.0-rc1`

### DIFF
--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -57,9 +57,9 @@ in
 
       ibc-go-v7-simapp = {
         name = "simapp";
-        version = "v7.0.0-pre.0";
+        version = "v7.0.0-rc1";
         src = ibc-go-v7-src;
-        vendorSha256 = "sha256-tTQ7kODkWvp9rSoP6yJ/JKuJkqvRh5klNNENC0CJMDM";
+        vendorSha256 = "sha256-tTQ7kODkWvp9rSoP6yJ/JKuJkqvRh5klNNENC0CJMDM=";
         tags = ["netgo"];
         excludedPackages = ["./e2e"];
       };


### PR DESCRIPTION
Ibc-go `simd` released `v7.0.0-rc1` which replaced Tendermint with CometBFT `v0.37`, https://github.com/cosmos/ibc-go/releases/tag/v7.0.0-rc1.