### PR TITLE
Update Osmosis from v14.0.0 to v15.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,16 +539,16 @@
     "osmosis-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1673971085,
-        "narHash": "sha256-u14TpwHMheenEjdwXYZdW9HoG1/iktEPwjnluKyOlNk=",
+        "lastModified": 1678471069,
+        "narHash": "sha256-+BzlHD2W+tmj0tybGtqFXVeAzlaBZ47yCC/fTPDYq4E=",
         "owner": "osmosis-labs",
         "repo": "osmosis",
-        "rev": "62587bfa0db9309804ca84cfceca6a19ac0aae44",
+        "rev": "ff18d8244fcda7313ec951fb1b3bee8369b8316b",
         "type": "github"
       },
       "original": {
         "owner": "osmosis-labs",
-        "ref": "v14.0.0",
+        "ref": "v15.0.0",
         "repo": "osmosis",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
     juno-src.url = github:CosmosContracts/juno/v2.3.0-beta.2;
 
     osmosis-src.flake = false;
-    osmosis-src.url = github:osmosis-labs/osmosis/v14.0.0;
+    osmosis-src.url = github:osmosis-labs/osmosis/v15.0.0;
 
     osmosis7-src.flake = false;
     osmosis7-src.url = github:osmosis-labs/osmosis/v7.3.0;

--- a/resources.nix
+++ b/resources.nix
@@ -97,9 +97,9 @@
 
       osmosis = utilities.mkCosmosGoApp {
         name = "osmosis";
-        version = "v14.0.0";
+        version = "v15.0.0";
         src = inputs.osmosis-src;
-        vendorSha256 = "sha256-wmhvk2cLdSch2Q5j3VhsVeELITdxDNyJXOla8cilx1U=";
+        vendorSha256 = "sha256-4RNRAtQmWdi9ZYUH7Rn5VRef/ZhGB7WDwyelUf+U/rc=";
         tags = ["netgo"];
         preFixup = ''
           ${utilities.wasmdPreFixupPhase "osmosisd"}


### PR DESCRIPTION
Update Osmosis from `v14.0.0` to `v15.0.0` as it is the version currently being used, see https://cosmos.directory/osmosis/chain