### PR TITLE
Add branch `04-channel-upgrades` of `ibc-go` simapp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,17 +358,17 @@
     "ibc-go-v7-channel-upgrade-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681914625,
-        "narHash": "sha256-MaUx988kvPc5AAlDiEPB0o0t+h+JyB3LsEFvPOvogQE=",
+        "lastModified": 1688114595,
+        "narHash": "sha256-jsEHc27nlK8wIBz1d7pgcSMDuDPt6zsXeYwrludF8dY=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "81a709b49a42504737d25be0e812d830f9a0897c",
+        "rev": "a7793bc10425d6f01e0b00a63520166837990221",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "81a709b49a42504737d25be0e812d830f9a0897c",
+        "rev": "a7793bc10425d6f01e0b00a63520166837990221",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -429,17 +429,17 @@
     "ibc-go-v7-channel-upgrade-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1689769107,
-        "narHash": "sha256-BadLMNoREpix9Bko7I9PhdkhIMjCoco8opO7HvWnbBs=",
+        "lastModified": 1692787150,
+        "narHash": "sha256-2EicMXlcBneBR5NwpAyVZ/uSvLaWrJEKLmb5/H+o/Ls=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "82ea9531e24855ef52e2dae629d579583a0e830f",
+        "rev": "f1e8ae805a3633d47928cfc02315a1a19ca80a0e",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "82ea9531e24855ef52e2dae629d579583a0e830f",
+        "rev": "f1e8ae805a3633d47928cfc02315a1a19ca80a0e",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -358,17 +358,17 @@
     "ibc-go-v7-channel-upgrade-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1688664894,
-        "narHash": "sha256-VbfTuyabgbzC4XIMQ4pDKagdPF9a7m7uVnyKCtBnw1E=",
+        "lastModified": 1689769107,
+        "narHash": "sha256-BadLMNoREpix9Bko7I9PhdkhIMjCoco8opO7HvWnbBs=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "3203f07f10c76d17e094773754f5da10c49933c5",
+        "rev": "82ea9531e24855ef52e2dae629d579583a0e830f",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "3203f07f10c76d17e094773754f5da10c49933c5",
+        "rev": "82ea9531e24855ef52e2dae629d579583a0e830f",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -355,6 +355,23 @@
         "type": "github"
       }
     },
+    "ibc-go-v7-channel-upgrade-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681914625,
+        "narHash": "sha256-MaUx988kvPc5AAlDiEPB0o0t+h+JyB3LsEFvPOvogQE=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "81a709b49a42504737d25be0e812d830f9a0897c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "81a709b49a42504737d25be0e812d830f9a0897c",
+        "type": "github"
+      }
+    },
     "ibc-go-v7-src": {
       "flake": false,
       "locked": {
@@ -701,6 +718,7 @@
         "ibc-go-v4-src": "ibc-go-v4-src",
         "ibc-go-v5-src": "ibc-go-v5-src",
         "ibc-go-v6-src": "ibc-go-v6-src",
+        "ibc-go-v7-channel-upgrade-src": "ibc-go-v7-channel-upgrade-src",
         "ibc-go-v7-src": "ibc-go-v7-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",

--- a/flake.lock
+++ b/flake.lock
@@ -358,17 +358,17 @@
     "ibc-go-v7-channel-upgrade-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1688114595,
-        "narHash": "sha256-jsEHc27nlK8wIBz1d7pgcSMDuDPt6zsXeYwrludF8dY=",
+        "lastModified": 1688664894,
+        "narHash": "sha256-VbfTuyabgbzC4XIMQ4pDKagdPF9a7m7uVnyKCtBnw1E=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "a7793bc10425d6f01e0b00a63520166837990221",
+        "rev": "3203f07f10c76d17e094773754f5da10c49933c5",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "a7793bc10425d6f01e0b00a63520166837990221",
+        "rev": "3203f07f10c76d17e094773754f5da10c49933c5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.1.0;
 
     ibc-go-v7-channel-upgrade-src.flake = false;
-    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/82ea9531e24855ef52e2dae629d579583a0e830f;
+    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/f1e8ae805a3633d47928cfc02315a1a19ca80a0e;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.1.0;
 
     ibc-go-v7-channel-upgrade-src.flake = false;
-    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/3203f07f10c76d17e094773754f5da10c49933c5;
+    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/82ea9531e24855ef52e2dae629d579583a0e830f;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.1.0;
 
     ibc-go-v7-channel-upgrade-src.flake = false;
-    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/a7793bc10425d6f01e0b00a63520166837990221;
+    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/3203f07f10c76d17e094773754f5da10c49933c5;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,9 @@
     ibc-go-v7-src.flake = false;
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.0.0;
 
+    ibc-go-v7-channel-upgrade-src.flake = false;
+    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/81a709b49a42504737d25be0e812d830f9a0897c;
+
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;
 

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.1.0;
 
     ibc-go-v7-channel-upgrade-src.flake = false;
-    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/81a709b49a42504737d25be0e812d830f9a0897c;
+    ibc-go-v7-channel-upgrade-src.url = github:cosmos/ibc-go/a7793bc10425d6f01e0b00a63520166837990221;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -70,4 +70,14 @@ in
         doCheck = false;
         excludedPackages = ["./e2e"];
       };
+
+      ibc-go-v7-channel-upgrade = {
+        name = "simapp";
+        version = "v7.0.0-channel.upgrade";
+        src = inputs.ibc-go-v7-channel-upgrade-src;
+        vendorSha256 = "sha256-KXF3wzXrvmm3LL+3SEGISNGedTfNlt1i1mjApV2dRDk=";
+        tags = ["netgo"];
+        engine = "cometbft/cometbft";
+        excludedPackages = ["./e2e"];
+      };
     }

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -75,7 +75,7 @@ in
         name = "simapp";
         version = "v7.0.0-channel.upgrade";
         src = inputs.ibc-go-v7-channel-upgrade-src;
-        vendorSha256 = "sha256-KXF3wzXrvmm3LL+3SEGISNGedTfNlt1i1mjApV2dRDk=";
+        vendorSha256 = "sha256-ugCYnE7LfuHyN4o7etY7kajsYXo7tNc4/y3Mzoahy6s=";
         tags = ["netgo"];
         engine = "cometbft/cometbft";
         excludedPackages = ["./e2e"];


### PR DESCRIPTION
No need to merge this, we will only use it from Hermes while we implement support for channel upgrades and until it is released in `ibc-go`.