### PR TITLE
Update Evmos, Gaia and Stride chains

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,16 +71,16 @@
     "evmos-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1657722808,
-        "narHash": "sha256-WHo4DEaTwJXs3QGSGIRxqkaJFS6D96/zyXVmkaH867s=",
+        "lastModified": 1666728289,
+        "narHash": "sha256-hMry1q+31jqSe0krg880LIMcz0xgftB3mwfywWoLX3w=",
         "owner": "tharsis",
         "repo": "evmos",
-        "rev": "5f59c0f8393e15ff5894e6450567b534c498a428",
+        "rev": "80c38f659a65a983b221e2a568c6172b8ac3bffc",
         "type": "github"
       },
       "original": {
         "owner": "tharsis",
-        "ref": "v6.0.2",
+        "ref": "v9.1.0",
         "repo": "evmos",
         "type": "github"
       }
@@ -235,16 +235,16 @@
     "gaia9-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1678387146,
-        "narHash": "sha256-xE6jZKIgmZ+/bFUWrdoyOy73fsC1VdYfhxH9u4tD7HI=",
+        "lastModified": 1681924944,
+        "narHash": "sha256-UIM6yfqs1yZZ2BO/bBB43pPYSW1IzaYsk2f500tDYzA=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "4b14265197d9beeb6c8b0d407433c852a5af6422",
+        "rev": "05b6b87d3c9121e933eab437772ea56f33ae268f",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v9.0.1",
+        "ref": "v9.0.3",
         "repo": "gaia",
         "type": "github"
       }
@@ -476,16 +476,16 @@
     "juno-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1679292088,
-        "narHash": "sha256-9xWOnlqjJWY7dyICYjl1Fmqi27352TF9ihcbZBI/Dps=",
+        "lastModified": 1681847717,
+        "narHash": "sha256-dztSBe7dPYKmB5FeoZJuz7oel7a7Wx4muTGyABFn05M=",
         "owner": "CosmosContracts",
         "repo": "juno",
-        "rev": "1f392744afd9829f3f7837fe6f13800a19bad961",
+        "rev": "e57bc002ac3d27457e304985a4cd8445a2580172",
         "type": "github"
       },
       "original": {
         "owner": "CosmosContracts",
-        "ref": "v13.0.1",
+        "ref": "v14.1.0",
         "repo": "juno",
         "type": "github"
       }
@@ -733,6 +733,7 @@
         "wasmvm_0_16_3-src": "wasmvm_0_16_3-src",
         "wasmvm_1-src": "wasmvm_1-src",
         "wasmvm_1_1_1-src": "wasmvm_1_1_1-src",
+        "wasmvm_1_2_3-src": "wasmvm_1_2_3-src",
         "wasmvm_1_beta7-src": "wasmvm_1_beta7-src"
       }
     },
@@ -856,16 +857,16 @@
     "stride-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1678771112,
-        "narHash": "sha256-c971YXdUSVhpEQFDuBNsG1DooOus1ps0jw4x6haTSdU=",
+        "lastModified": 1679819302,
+        "narHash": "sha256-fdjnFHPBZNnhDyVoMuPfqNb6YUYRdcMO73FlZHjIuzA=",
         "owner": "Stride-Labs",
         "repo": "stride",
-        "rev": "ef4808d4095c3da3c4f35e1b37495b5813624d14",
+        "rev": "3c69e7644859981b1fd9313eb1f0c5e5886e4a0d",
         "type": "github"
       },
       "original": {
         "owner": "Stride-Labs",
-        "ref": "v7.0.0",
+        "ref": "v8.0.0",
         "repo": "stride",
         "type": "github"
       }
@@ -985,6 +986,23 @@
       "original": {
         "owner": "CosmWasm",
         "ref": "v1.1.1",
+        "repo": "wasmvm",
+        "type": "github"
+      }
+    },
+    "wasmvm_1_2_3-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681831436,
+        "narHash": "sha256-GscUMJ0Tkg77S9IYA9komyKKoa1AyVXSSaU8hw3ZNwk=",
+        "owner": "CosmWasm",
+        "repo": "wasmvm",
+        "rev": "61e41ae2a80081224f469614a267b0ba2a2d305f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CosmWasm",
+        "ref": "v1.2.3",
         "repo": "wasmvm",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     gaia-main-src.url = github:cosmos/gaia;
 
     gaia9-src.flake = false;
-    gaia9-src.url = github:cosmos/gaia/v9.0.1;
+    gaia9-src.url = github:cosmos/gaia/v9.0.3;
 
     gaia8-src.flake = false;
     gaia8-src.url = github:cosmos/gaia/v8.0.1;
@@ -86,10 +86,10 @@
     regen-src.url = github:regen-network/regen-ledger/v3.0.0;
 
     evmos-src.flake = false;
-    evmos-src.url = github:tharsis/evmos/v6.0.2;
+    evmos-src.url = github:tharsis/evmos/v9.1.0;
 
     juno-src.flake = false;
-    juno-src.url = github:CosmosContracts/juno/v13.0.1;
+    juno-src.url = github:CosmosContracts/juno/v14.1.0;
 
     osmosis-src.flake = false;
     osmosis-src.url = github:osmosis-labs/osmosis/v15.0.0;
@@ -136,6 +136,9 @@
     wasmvm_1_1_1-src.flake = false;
     wasmvm_1_1_1-src.url = github:CosmWasm/wasmvm/v1.1.1;
 
+    wasmvm_1_2_3-src.flake = false;
+    wasmvm_1_2_3-src.url = github:CosmWasm/wasmvm/v1.2.3;
+
     wasmvm_1_beta7-src.flake = false;
     wasmvm_1_beta7-src.url = github:CosmWasm/wasmvm/v1.0.0-beta7;
 
@@ -152,7 +155,7 @@
     interchain-security-src.url = github:cosmos/interchain-security/v0.1.4;
 
     stride-src.flake = false;
-    stride-src.url = github:Stride-Labs/stride/v7.0.0;
+    stride-src.url = github:Stride-Labs/stride/v8.0.0;
   };
 
   outputs = inputs:

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
     evmos-src.url = github:tharsis/evmos/v9.1.0;
 
     juno-src.flake = false;
-    juno-src.url = github:CosmosContracts/juno/v14.1.0;
+    juno-src.url = github:CosmosContracts/juno/v13.0.1;
 
     osmosis-src.flake = false;
     osmosis-src.url = github:osmosis-labs/osmosis/v15.0.0;
@@ -135,9 +135,6 @@
 
     wasmvm_1_1_1-src.flake = false;
     wasmvm_1_1_1-src.url = github:CosmWasm/wasmvm/v1.1.1;
-
-    wasmvm_1_2_3-src.flake = false;
-    wasmvm_1_2_3-src.url = github:CosmWasm/wasmvm/v1.2.3;
 
     wasmvm_1_beta7-src.flake = false;
     wasmvm_1_beta7-src.url = github:CosmWasm/wasmvm/v1.0.0-beta7;

--- a/patches/stride-no-admin-check.patch
+++ b/patches/stride-no-admin-check.patch
@@ -1,5 +1,5 @@
 diff --git a/utils/utils.go b/utils/utils.go
-index bb2db250..8fe5a175 100644
+index 74ff4794..cb2a6f37 100644
 --- a/utils/utils.go
 +++ b/utils/utils.go
 @@ -35,9 +35,6 @@ func Int64ToCoinString(amount int64, denom string) string {

--- a/resources.nix
+++ b/resources.nix
@@ -160,7 +160,7 @@
         name = "juno";
         version = "v13.0.1";
         src = inputs.juno-src;
-        vendorSha256 = "sha256-y1LLpENPVxB4FA2Mb/HO9r3t3sxLFvY5LVypKe4J5Ug=";
+        vendorSha256 = "sha256-0EsEzkEY4N4paQ+OPV7MVUTwOr8F2uCCLi6NQ3JSlgM=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";
         preFixup = ''

--- a/resources.nix
+++ b/resources.nix
@@ -90,9 +90,9 @@
 
       evmos = utilities.mkCosmosGoApp {
         name = "evmos";
-        version = "v6.0.2";
+        version = "v9.1.0";
         src = inputs.evmos-src;
-        vendorSha256 = "sha256-sJxlg1dGU04P5nxuuh+1ljKX/IntgTcfjirV/6NDxjw=";
+        vendorSha256 = "sha256-AjWuufyAz5KTBwKiWvhPeqGm4fn3MUqg39xb4pJ0hTM=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";
       };
@@ -158,9 +158,9 @@
 
       juno = utilities.mkCosmosGoApp {
         name = "juno";
-        version = "v13.0.1";
+        version = "v14.1.0";
         src = inputs.juno-src;
-        vendorSha256 = "sha256-0EsEzkEY4N4paQ+OPV7MVUTwOr8F2uCCLi6NQ3JSlgM=";
+        vendorSha256 = "sha256-y1LLpENPVxB4FA2Mb/HO9r3t3sxLFvY5LVypKe4J5Ug=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";
         preFixup = ''
@@ -169,7 +169,7 @@
           ${utilities.wasmdPreFixupPhase "node"}
         '';
         dontStrip = true;
-        buildInputs = [libwasmvm_1_1_1];
+        buildInputs = [libwasmvm_1_2_3];
       };
 
       terra = utilities.mkCosmosGoApp {
@@ -302,7 +302,7 @@
 
       stride = utilities.mkCosmosGoApp {
         name = "stride";
-        version = "v7.0.0";
+        version = "v8.0.0";
         src = inputs.stride-src;
         vendorSha256 = "sha256-z4vT4CeoJF76GwljHm2L2UF1JxyEJtvqAkP9TmIgs10=";
         engine = "tendermint/tendermint";
@@ -312,7 +312,7 @@
 
       stride-no-admin = utilities.mkCosmosGoApp {
         name = "stride-no-admin";
-        version = "v7.0.0";
+        version = "v8.0.0";
         src = inputs.stride-src;
         vendorSha256 = "sha256-z4vT4CeoJF76GwljHm2L2UF1JxyEJtvqAkP9TmIgs10=";
         engine = "tendermint/tendermint";
@@ -328,6 +328,19 @@
         src = inputs.ibc-rs-src;
         nativeBuildInputs = with pkgs; [rust-bin.stable.latest.default];
         cargoSha256 = "sha256-0GZN3xq/5FC/jYXGVDIOrha+sB+Gv/6nzlFvpCAYO3M=";
+        doCheck = false;
+      };
+
+      libwasmvm_1_2_3 = pkgs.rustPlatform.buildRustPackage {
+        pname = "libwasmvm";
+        src = "${inputs.wasmvm_1_2_3-src}/libwasmvm";
+        version = "v1.2.3";
+        nativeBuildInputs = with pkgs; [rust-bin.stable.latest.default];
+        postInstall = ''
+          cp ./bindings.h $out/lib/
+          ln -s $out/lib/libwasmvm.so $out/lib/libwasmvm.${builtins.head (pkgs.lib.strings.splitString "-" system)}.so
+        '';
+        cargoSha256 = "sha256-+BaILTe+3qlI+/nz7Nub2hPKiDZlLdL58ckmiBxJtsk=";
         doCheck = false;
       };
 

--- a/resources.nix
+++ b/resources.nix
@@ -158,9 +158,8 @@
 
       juno = utilities.mkCosmosGoApp {
         name = "juno";
-        version = "v14.1.0";
+        version = "v13.0.1";
         src = inputs.juno-src;
-        excludedPackages = "./tests/interchaintest";
         vendorSha256 = "sha256-y1LLpENPVxB4FA2Mb/HO9r3t3sxLFvY5LVypKe4J5Ug=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";
@@ -170,7 +169,7 @@
           ${utilities.wasmdPreFixupPhase "node"}
         '';
         dontStrip = true;
-        buildInputs = [libwasmvm_1_2_3];
+        buildInputs = [libwasmvm_1_1_1];
       };
 
       terra = utilities.mkCosmosGoApp {
@@ -329,19 +328,6 @@
         src = inputs.ibc-rs-src;
         nativeBuildInputs = with pkgs; [rust-bin.stable.latest.default];
         cargoSha256 = "sha256-0GZN3xq/5FC/jYXGVDIOrha+sB+Gv/6nzlFvpCAYO3M=";
-        doCheck = false;
-      };
-
-      libwasmvm_1_2_3 = pkgs.rustPlatform.buildRustPackage {
-        pname = "libwasmvm";
-        src = "${inputs.wasmvm_1_2_3-src}/libwasmvm";
-        version = "v1.2.3";
-        nativeBuildInputs = with pkgs; [rust-bin.stable.latest.default];
-        postInstall = ''
-          cp ./bindings.h $out/lib/
-          ln -s $out/lib/libwasmvm.so $out/lib/libwasmvm.${builtins.head (pkgs.lib.strings.splitString "-" system)}.so
-        '';
-        cargoSha256 = "sha256-+BaILTe+3qlI+/nz7Nub2hPKiDZlLdL58ckmiBxJtsk=";
         doCheck = false;
       };
 

--- a/resources.nix
+++ b/resources.nix
@@ -160,6 +160,7 @@
         name = "juno";
         version = "v14.1.0";
         src = inputs.juno-src;
+        excludedPackages = "./tests/interchaintest";
         vendorSha256 = "sha256-y1LLpENPVxB4FA2Mb/HO9r3t3sxLFvY5LVypKe4J5Ug=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";

--- a/resources/gaia/default.nix
+++ b/resources/gaia/default.nix
@@ -75,11 +75,11 @@ in
 
       gaia9 = {
         name = "gaia";
-        vendorSha256 = "sha256-qwHc7F4yYJji/nnG5hBNOSmtF7SjTv8eO7e7IvmgV98=";
-        version = "v9.0.1";
+        vendorSha256 = "sha256-W1pKtrWfXe0pdO7ntcjFbDa0LTpD91yI2mUMXBiDo1w=";
+        version = "v9.0.3";
         src = gaia9-src;
         tags = ["netgo"];
-        engine = "tendermint/tendermint";
+        engine = "cometbft/cometbft";
         proxyVendor = true;
 
         # Tests have to be disabled because they require Docker to run


### PR DESCRIPTION
This PR updates the following chains:

* Evmos from `v6.0.2` to `v9.1.0`
* Gaia from `v9.0.1` to `v9.0.3`
* Stride from `v7.0.0` to `v8.0.0`
* ~Juno from `v13.0.1` to `v14.1.0`~
  * Juno requires some additional tweaks and will be updated in a separate PR