### PR TITLE
Update vendorSha256 for cosmos/relayer in resources.nix file

### DIFF
--- a/resources.nix
+++ b/resources.nix
@@ -278,7 +278,7 @@
       relayer = pkgs.buildGoModule {
         name = "relayer";
         src = inputs.relayer-src;
-        vendorSha256 = "sha256-AelUjtgI9Oua++5TL/MEAAOgxZVxhOW2vEEhNdH3aBk=";
+        vendorSha256 = "sha256-oJSxRUKXhjpDWk0bk7Q8r0AAc7UOhEOLj+SgsZsnzsk=";
         doCheck = false;
       };
 


### PR DESCRIPTION
This PR aims to fix the following error while building cosmos/relayer via "nix build .#relayer" command.

$ nix build .#relayer

error: hash mismatch in fixed-output derivation '/nix/store/cvrqsrvk6vik2r5k65yzrmskzv3mhx00-relayer-go-modules.drv':
         specified: sha256-AelUjtgI9Oua++5TL/MEAAOgxZVxhOW2vEEhNdH3aBk=
            got:    sha256-oJSxRUKXhjpDWk0bk7Q8r0AAc7UOhEOLj+SgsZsnzsk=
error: 1 dependencies of derivation '/nix/store/xz50gfl88xin3ziaynpnjrkp9hnybcpn-relayer.drv' failed to build
