### PR TITLE
Update ibc-go simapp from `v7.0.0` to `v7.1.0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,16 +358,16 @@
     "ibc-go-v7-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1678970403,
-        "narHash": "sha256-vdsDqLHpP0Bp0j8gtDOdouzyQXKioZsxJA+znkQw6JY=",
+        "lastModified": 1686298823,
+        "narHash": "sha256-8ModVWpRWbwWQLj5BCCopn7vpOJjFp4ISESCCp4pqWQ=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "7fb65c76000f207ece1b83d8950e3aaff3dfc0e7",
+        "rev": "000e9d20b15b3c6939cefc0e26daa4b64c1be8fb",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.0.0",
+        "ref": "v7.1.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
     ibc-go-v6-src.url = github:cosmos/ibc-go/v6.1.0;
 
     ibc-go-v7-src.flake = false;
-    ibc-go-v7-src.url = github:cosmos/ibc-go/v7.0.0;
+    ibc-go-v7-src.url = github:cosmos/ibc-go/v7.1.0;
 
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -62,9 +62,9 @@ in
 
       ibc-go-v7-simapp = {
         name = "simd";
-        version = "v7.0.0";
+        version = "v7.1.0";
         src = inputs.ibc-go-v7-src;
-        vendorSha256 = "sha256-KXF3wzXrvmm3LL+3SEGISNGedTfNlt1i1mjApV2dRDk=";
+        vendorSha256 = "sha256-Z0/ac2gsGeyp37teM5bF5KqW4/Y88LMjo2eiS1y1WTs=";
         tags = ["netgo"];
         engine = "cometbft/cometbft";
         doCheck = false;


### PR DESCRIPTION
This PR updates the ibc-go simapp version from `v7.0.0` to `v7.1.0`