### PR TITLE
Add `ibc-go-sdk-50-simapp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check 🔎
         run: |
-          nix flake check --keep-going --print-build-logs
+          nix flake check --print-build-logs
 
       - name: Run Shell 🐚
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check 🔎
         run: |
-          nix flake check --print-build-logs
+          nix flake check --keep-going --print-build-logs
 
       - name: Run Shell 🐚
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -136,12 +136,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -152,7 +155,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -168,14 +171,29 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gaia-main-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1664958609,
-        "narHash": "sha256-w9tJJXimf0AhYhgColCjdHGh14sAId0Svtz/hHNYNlI=",
+        "lastModified": 1692202984,
+        "narHash": "sha256-Rxu5atZuMw0cmm4oNQW8N0Pp7LnTlOdo/RQHt6xmETc=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "4d3a104f6ce6f441e6588cdb8fa6e600396ad3ac",
+        "rev": "75f0714294d2a43462cc2a9e53a1762882d468b6",
         "type": "github"
       },
       "original": {
@@ -353,8 +371,8 @@
       },
       "original": {
         "owner": "cosmos",
-        "ref": "upgrade-sdk-v0.50-alpha1",
         "repo": "ibc-go",
+        "rev": "72bf69064fbec71147216a53378bd310c74b0fef",
         "type": "github"
       }
     },
@@ -480,11 +498,11 @@
     "ica-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647255020,
-        "narHash": "sha256-Ah5pivnAmk3W0fLWnrBbi84tqwJYQETSILSvNVH6fI8=",
+        "lastModified": 1679480012,
+        "narHash": "sha256-LFyInZT7z/8/d3RYepYf95ryxA7Pbg3TMQhHrHUvlCA=",
         "owner": "cosmos",
         "repo": "interchain-accounts-demo",
-        "rev": "09b6a493a84a135f395d74d5ec82ea983617a714",
+        "rev": "fe07f304731161055cecec120e0d2de01e84bad4",
         "type": "github"
       },
       "original": {
@@ -614,11 +632,11 @@
     },
     "nix-std": {
       "locked": {
-        "lastModified": 1658944356,
-        "narHash": "sha256-+nBrRSPsDIjrmLfLdiB/a22Gj4bhEF53ubWN0z33NJo=",
+        "lastModified": 1685917625,
+        "narHash": "sha256-2manVKofCZrCToVDnDYNvtYUFBYOM5JhdDoNGVY4fq4=",
         "owner": "chessai",
         "repo": "nix-std",
-        "rev": "9500903a19ef2720469578de0e10ce9e66623bdf",
+        "rev": "e20af8822b5739434b875643bfc61fe0195ea2fb",
         "type": "github"
       },
       "original": {
@@ -629,11 +647,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673947312,
-        "narHash": "sha256-xx/2nRwRy3bXrtry6TtydKpJpqHahjuDB5sFkQ/XNDE=",
+        "lastModified": 1692311226,
+        "narHash": "sha256-mRzNup0PIUD6YxbrYvjzL7f+1oaOGy9nmGCV3AZkQus=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d38b664b4400335086a713a0036aafaa002c003",
+        "rev": "ef8288935ba859fc3b30632fa6e04705f81b9c2a",
         "type": "github"
       },
       "original": {
@@ -645,16 +663,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -666,6 +684,22 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1674990008,
+        "narHash": "sha256-4zOyp+hFW2Y7imxIpZqZGT8CEqKmDjwgfD6BzRUE0mQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d2bbcbe6c626d339b25a4995711f07625b508214",
         "type": "github"
       },
       "original": {
@@ -692,57 +726,6 @@
         "type": "github"
       }
     },
-    "osmosis6-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1646678581,
-        "narHash": "sha256-fGcz33PPA5dJ4J9vgfbYvBxNydu3/YuKSCf8pZkn5PM=",
-        "owner": "osmosis-labs",
-        "repo": "osmosis",
-        "rev": "2b61fd38505dbcbad08e78c96b7ab17e7ae1c85d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "osmosis-labs",
-        "ref": "v6.4.1",
-        "repo": "osmosis",
-        "type": "github"
-      }
-    },
-    "osmosis7-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1651600564,
-        "narHash": "sha256-aY6L+5Iw5tu/QOZ1ZgZq163MCy4ZZDHVl53MhZ8AyS4=",
-        "owner": "osmosis-labs",
-        "repo": "osmosis",
-        "rev": "ab02323b075e2573cd7a54736d705c88797d11c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "osmosis-labs",
-        "ref": "v7.3.0",
-        "repo": "osmosis",
-        "type": "github"
-      }
-    },
-    "osmosis8-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652595598,
-        "narHash": "sha256-upQzIJnzswT+HO6H0welw/X5n4F/K1k/dP4FQMOeC8Q=",
-        "owner": "osmosis-labs",
-        "repo": "osmosis",
-        "rev": "16e3b51f19a58f815a4eabcbcee11886eb33e026",
-        "type": "github"
-      },
-      "original": {
-        "owner": "osmosis-labs",
-        "ref": "v8.0.0",
-        "repo": "osmosis",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -756,11 +739,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674122161,
-        "narHash": "sha256-9QM4rvgUSEwO8DWtJN9sR/afEqrH1s3b6ACsZT5wiAM=",
+        "lastModified": 1692274144,
+        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "53e766957b73298fa68b47478c48cbcc005cc18a",
+        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
         "type": "github"
       },
       "original": {
@@ -841,9 +824,6 @@
         "nix-std": "nix-std",
         "nixpkgs": "nixpkgs",
         "osmosis-src": "osmosis-src",
-        "osmosis6-src": "osmosis6-src",
-        "osmosis7-src": "osmosis7-src",
-        "osmosis8-src": "osmosis8-src",
         "pre-commit-hooks": "pre-commit-hooks",
         "regen-src": "regen-src",
         "relayer-src": "relayer-src",
@@ -856,7 +836,6 @@
         "stoml-src": "stoml-src",
         "stride-consumer-src": "stride-consumer-src",
         "stride-src": "stride-src",
-        "terra-src": "terra-src",
         "ts-relayer-src": "ts-relayer-src",
         "umee-src": "umee-src",
         "wasmd-src": "wasmd-src",
@@ -891,12 +870,16 @@
       }
     },
     "sbt-derivation": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1617466857,
-        "narHash": "sha256-Z7eWMLreLtiSiJ3nWDWBy1w9WNEFexkYCgT/dWZF7yo=",
+        "lastModified": 1675083208,
+        "narHash": "sha256-+sSFhSpV2jckr1qYlX/SaxQ6IdpagD6o4rru/3HAl0I=",
         "owner": "zaninime",
         "repo": "sbt-derivation",
-        "rev": "920b6f187937493371e2b1687261017e6e014cf1",
+        "rev": "92d6d6d825e3f6ae5642d1cce8ff571c3368aaf7",
         "type": "github"
       },
       "original": {
@@ -908,11 +891,11 @@
     "sconfig-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1594094862,
-        "narHash": "sha256-jR2hkR0YlPyW2nKWJl90kL80R+9psNKGPYxGg7Y/YGw=",
+        "lastModified": 1679585941,
+        "narHash": "sha256-ywh9IcqMWbRHqJkGJezcDCvfbBYNJH7ualKvPJQRcHA=",
         "owner": "freshautomations",
         "repo": "sconfig",
-        "rev": "88043754c024aec433b3b059af170b6f555931c3",
+        "rev": "41450b55f3b37b4b7a0fdf4a69c707619dbeb47c",
         "type": "github"
       },
       "original": {
@@ -975,11 +958,11 @@
     "stoml-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1622172633,
-        "narHash": "sha256-PvKkOjjWkmK90PzKcOBq0pUWLjHLjfYs9PRqqzAR7/8=",
+        "lastModified": 1666796497,
+        "narHash": "sha256-Adjag1/Hd2wrar2/anD6jQEMDvUc2TOIG7DlEgxpTXc=",
         "owner": "freshautomations",
         "repo": "stoml",
-        "rev": "f5dab84dbf52345a1f36389aec38b02fda086a47",
+        "rev": "4b2cd09b5795a54fddc215f0d24e24071894b3cf",
         "type": "github"
       },
       "original": {
@@ -1037,20 +1020,18 @@
         "type": "github"
       }
     },
-    "terra-src": {
-      "flake": false,
+    "systems_2": {
       "locked": {
-        "lastModified": 1645516218,
-        "narHash": "sha256-7cmVYWFLeOZJtbfw8qaVKLDMVafoeFDXOcrmrMS9buE=",
-        "owner": "terra-money",
-        "repo": "core",
-        "rev": "a6b93b72a7d4fabbbb85fb89e685426f5d07cac1",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "terra-money",
-        "ref": "v0.5.17",
-        "repo": "core",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -1074,11 +1055,11 @@
     "umee-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1648176855,
-        "narHash": "sha256-s7MnAaM+O84JDO1uBNZm1qGN6ZfYmhXD5rCvns4u/rc=",
+        "lastModified": 1649261156,
+        "narHash": "sha256-hydRL/88fHCW/k7z7GoqAwvynZuvLEDLyA6A9Cm+6UY=",
         "owner": "umee-network",
         "repo": "umee",
-        "rev": "3c9b8db04d6ab19d31e89df65232abc35d1a8a59",
+        "rev": "42f57545251ce5337dcc5fe4309520ead89183b9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -371,8 +371,8 @@
       },
       "original": {
         "owner": "cosmos",
+        "ref": "upgrade-sdk-v0.50-alpha1",
         "repo": "ibc-go",
-        "rev": "72bf69064fbec71147216a53378bd310c74b0fef",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -341,6 +341,23 @@
         "type": "github"
       }
     },
+    "ibc-go-sdk-50-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690303739,
+        "narHash": "sha256-BVcWs8meTXGx192pVorCFQ0SeeX3zagfReKFyifewwM=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "72bf69064fbec71147216a53378bd310c74b0fef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "upgrade-sdk-v0.50-alpha1",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
     "ibc-go-v2-src": {
       "flake": false,
       "locked": {
@@ -805,6 +822,7 @@
         "gaia9-src": "gaia9-src",
         "gex-src": "gex-src",
         "hermes-src": "hermes-src",
+        "ibc-go-sdk-50-src": "ibc-go-sdk-50-src",
         "ibc-go-v2-src": "ibc-go-v2-src",
         "ibc-go-v3-src": "ibc-go-v3-src",
         "ibc-go-v4-src": "ibc-go-v4-src",

--- a/flake.nix
+++ b/flake.nix
@@ -100,18 +100,6 @@
     osmosis-src.flake = false;
     osmosis-src.url = github:osmosis-labs/osmosis/v15.2.0;
 
-    osmosis7-src.flake = false;
-    osmosis7-src.url = github:osmosis-labs/osmosis/v7.3.0;
-
-    osmosis6-src.flake = false;
-    osmosis6-src.url = github:osmosis-labs/osmosis/v6.4.1;
-
-    osmosis8-src.flake = false;
-    osmosis8-src.url = github:osmosis-labs/osmosis/v8.0.0;
-
-    terra-src.flake = false;
-    terra-src.url = github:terra-money/core/v0.5.17;
-
     sentinel-src.flake = false;
     sentinel-src.url = github:sentinel-official/hub/v0.9.0-rc0;
 
@@ -330,21 +318,6 @@
             drv = packages.osmosis;
             exePath = "/bin/osmosisd";
           };
-          osmosis7 = mkApp {
-            name = "osmosis";
-            drv = packages.osmosis7;
-            exePath = "/bin/osmosisd";
-          };
-          osmosis6 = mkApp {
-            name = "osmosis";
-            drv = packages.osmosis6;
-            exePath = "/bin/osmosisd";
-          };
-          osmosis8 = mkApp {
-            name = "osmosis";
-            drv = packages.osmosis8;
-            exePath = "/bin/osmosisd";
-          };
           iris = mkApp {
             name = "iris";
             drv = packages.iris;
@@ -370,11 +343,6 @@
             name = "juno";
             drv = packages.juno;
             exePath = "/bin/junod";
-          };
-          terra = mkApp {
-            name = "terra";
-            drv = packages.terra;
-            exePath = "/bin/terrad";
           };
           sentinel = mkApp {
             name = "sentinel";

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,9 @@
     ibc-go-v7-src.flake = false;
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.2.0;
 
+    ibc-go-sdk-50-src.flake = false;
+    ibc-go-sdk-50-src.url = github:cosmos/ibc-go/upgrade-sdk-v0.50-alpha1;
+
     cosmos-sdk-src.flake = false;
     cosmos-sdk-src.url = github:cosmos/cosmos-sdk/v0.46.0;
 
@@ -296,6 +299,10 @@
           ibc-go-v7-simapp = mkApp {
             name = "simd";
             drv = packages.ibc-go-v7-simapp;
+          };
+          ibc-go-sdk-50-simapp = mkApp {
+            name = "simd";
+            drv = packages.ibc-go-sdk-50-simapp;
           };
           ignite-cli = mkApp {
             name = "ignite-cli";

--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,7 @@
           inherit system;
           overlays = [
             inputs.rust-overlay.overlays.default
-            inputs.sbt-derivation.overlay
+            inputs.sbt-derivation.overlays.default
           ];
         };
         eval-pkgs = import inputs.nixpkgs {system = "x86_64-linux";};

--- a/resources.nix
+++ b/resources.nix
@@ -233,7 +233,7 @@
       ica = pkgs.buildGoModule {
         name = "ica";
         src = inputs.ica-src;
-        vendorSha256 = "sha256-ykGo5TQ+MiFoeQoglflQL3x3VN2CQuyZCIiweP/c9lM=";
+        vendorSha256 = "sha256-ZIP6dmHugLLtdA/8N8byg3D3JinjNxpvxyK/qiIs7bI=";
       };
 
       wasmd = utilities.mkCosmosGoApp {

--- a/resources.nix
+++ b/resources.nix
@@ -364,7 +364,7 @@
         cargoCheckCommand = "true";
       };
 
-      libwasmvm_1_2_4 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1_2_4 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1_2_4-src}/libwasmvm";
         version = "v1.2.4";
@@ -375,9 +375,15 @@
         '';
         cargoSha256 = "sha256-BFou838HI+YKXU9H53Xa/y7A441Z7Qkhf92mhquJ5l4=";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.2.6" = "sha256-6uhJijuDPXvEZG8mKBGyswsj/JR75Ui713BVx4XD7WI=";
+          };
+        };
       };
 
-      libwasmvm_1_2_3 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1_2_3 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1_2_3-src}/libwasmvm";
         version = "v1.2.3";
@@ -388,9 +394,15 @@
         '';
         cargoSha256 = "sha256-+BaILTe+3qlI+/nz7Nub2hPKiDZlLdL58ckmiBxJtsk=";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.2.4" = "sha256-8BHwgXRNHNB3V1tL+en3IfRHnyeygx5jYz7Sx6duWQg=";
+          };
+        };
       };
 
-      libwasmvm_1_1_2 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1_1_2 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1_1_2-src}/libwasmvm";
         version = "v1.1.2";
@@ -401,9 +413,15 @@
         '';
         cargoSha256 = "sha256-bCnr4TrI+jzvE91n2hhZMuBUPlrO1jXRbU/GFbRzs44=";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.1.10" = "sha256-i8tXVYVLguKd8oAwt8lc1aDzkxTtCaydrkl2X82Lw/Y=";
+          };
+        };
       };
 
-      libwasmvm_1_1_1 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1_1_1 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1_1_1-src}/libwasmvm";
         version = "v1.1.1";
@@ -414,9 +432,15 @@
         '';
         cargoSha256 = "sha256-97BhqI1FZyDbVrT5hdyEK7VPtpE9lQgWduc/siH6NqE";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.1.2" = "sha256-Phg/StSMZA74gGPyQpzjsy3qRO++AWWVnbcu1Ar0WCE=";
+          };
+        };
       };
 
-      libwasmvm_1 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1-src}/libwasmvm";
         version = "v1.0.0";
@@ -427,9 +451,15 @@
         '';
         cargoSha256 = "sha256-Q8j9wESn2RBb05LcS7FiKGTPLgIPxWA0GZqHlTjkqpU=";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.0.0" = "sha256-GuepzBF0BxbPatKZTiRwqPxJewbie+5gwBtOTLWOnng=";
+          };
+        };
       };
 
-      libwasmvm_1beta7 = pkgs.rustPlatform.buildRustPackage {
+      libwasmvm_1beta7 = pkgs.rustPlatform.buildRustPackage rec {
         pname = "libwasmvm";
         src = "${inputs.wasmvm_1_beta7-src}/libwasmvm";
         version = "v1.0.0-beta7";
@@ -439,6 +469,12 @@
         '';
         cargoSha256 = "sha256-G9wHl2JPgCDoMcykUAM0GrPUbMvSY5PbUzZ6G98rIO8=";
         doCheck = false;
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "cosmwasm-crypto-1.0.0-beta6" = "sha256-HnskwQ3fOrLG6ImgDYH+/nBYBqdWJDjPtcsTsUz8n2s=";
+          };
+        };
       };
 
       # Misc

--- a/resources.nix
+++ b/resources.nix
@@ -37,13 +37,13 @@
       stoml = pkgs.buildGoModule {
         name = "stoml";
         src = inputs.stoml-src;
-        vendorSha256 = "sha256-37PcS7qVQ+IVZddcm+KbUjRjql7KIzynVGKpIHAk5GY=";
+        vendorSha256 = "sha256-i5m2I0IApTwD9XIjsDwU4dpNtwGI0EGeSkY6VbXDOAM=";
       };
 
       sconfig = pkgs.buildGoModule {
         name = "sconfig";
         src = inputs.sconfig-src;
-        vendorSha256 = "sha256-ytpye6zEZC4oLrif8xe6Vr99lblule9HiAyZsSisIPg=";
+        vendorSha256 = "sha256-J3L8gPtCShn//3mliMzvRTxRgb86f1pJ+yjZkF5ixEk=";
       };
 
       cosmovisor = pkgs.buildGoModule {
@@ -169,7 +169,7 @@
         version = "v2.0.0";
         subPackages = ["cmd/umeed"];
         src = inputs.umee-src;
-        vendorSha256 = "sha256-HONlFCC6iHgKQwqAiEV29qmSHsLdloUlAeJkxViUG7w=";
+        vendorSha256 = "sha256-VXBB2ZBh4QFbGQm3bXsl63MeASZMI1++wnhm2IrDrwk=";
         tags = ["netgo"];
         engine = "tendermint/tendermint";
       };

--- a/resources.nix
+++ b/resources.nix
@@ -441,18 +441,6 @@
         doCheck = false;
       };
 
-      libwasmvm_0_16_3 = pkgs.rustPlatform.buildRustPackage {
-        pname = "libwasmvm";
-        src = "${inputs.wasmvm_0_16_3-src}/libwasmvm";
-        version = "v0.16.3";
-        nativeBuildInputs = with pkgs; [rust-bin.stable.latest.default];
-        postInstall = ''
-          cp ./bindings.h $out/lib/
-        '';
-        cargoSha256 = "sha256-MUTXxBCIYwCBCDNkFh+JrGMhKg20vC3wCGxqpZVa9Os=";
-        doCheck = false;
-      };
-
       # Misc
       gm = with pkgs;
         (import ./resources/gm) {

--- a/resources.nix
+++ b/resources.nix
@@ -116,46 +116,6 @@
         doCheck = false;
       };
 
-      osmosis6 = utilities.mkCosmosGoApp {
-        name = "osmosis";
-        version = "v6.4.1";
-        src = inputs.osmosis6-src;
-        vendorSha256 = "sha256-UI5QGQsTLPnsDWWPUG+REsvF4GIeFeNHOiG0unNXmdY=";
-        tags = ["netgo"];
-        engine = "tendermint/tendermint";
-      };
-
-      osmosis7 = utilities.mkCosmosGoApp {
-        name = "osmosis";
-        version = "v7.3.0";
-        src = inputs.osmosis7-src;
-        excludedPackages = "./tests/e2e";
-        vendorSha256 = "sha256-sdj59aZJBF4kpolHnYOHHO4zs7vKFu0i1xGKZFEiOyQ=";
-        tags = ["netgo"];
-        engine = "tendermint/tendermint";
-        preFixup = utilities.wasmdPreFixupPhase libwasmvm_1 "osmosisd";
-        buildInputs = [libwasmvm_1];
-
-        # Test has to be skipped as end-to-end testing requires network access
-        doCheck = false;
-      };
-
-      osmosis8 = utilities.mkCosmosGoApp {
-        name = "osmosis";
-        version = "v8.0.0";
-        src = inputs.osmosis8-src;
-        excludedPackages = "./tests/e2e";
-        vendorSha256 = "sha256-sdj59aZJBF4kpolHnYOHHO4zs7vKFu0i1xGKZFEiOyQ=";
-        tags = ["netgo"];
-        engine = "tendermint/tendermint";
-        preFixup = utilities.wasmdPreFixupPhase libwasmvm_1beta7 "osmosisd";
-        dontStrip = true;
-        buildInputs = [libwasmvm_1beta7];
-
-        # Test has to be skipped as end-to-end testing requires network access
-        doCheck = false;
-      };
-
       juno = utilities.mkCosmosGoApp {
         name = "juno";
         version = "v13.0.1";
@@ -170,18 +130,6 @@
         '';
         dontStrip = true;
         buildInputs = [libwasmvm_1_1_1];
-      };
-
-      terra = utilities.mkCosmosGoApp {
-        name = "terra";
-        version = "v0.5.17";
-        src = inputs.terra-src;
-        vendorSha256 = "sha256-2KmSRuSMzg9qFVncrxk+S5hqx8MMpRdo12/HZEaK5Aw=";
-        tags = ["netgo"];
-        engine = "tendermint/tendermint";
-        preFixup = utilities.wasmdPreFixupPhase libwasmvm_0_16_3 "terrad";
-        dontStrip = true;
-        buildInputs = [libwasmvm_0_16_3];
       };
 
       sentinel = utilities.mkCosmosGoApp {
@@ -582,7 +530,7 @@
         curl
         lz4
         python39
-        packages.osmosis8
+        packages.osmosis
         packages.cosmovisor
       ];
       shellHook = ''

--- a/resources/apalache.nix
+++ b/resources/apalache.nix
@@ -28,7 +28,7 @@
                    if (isSnapshot.value) (k -> build) else (k -> v)
   '';
 in
-  pkgs.sbt.mkDerivation {
+  pkgs.mkSbtDerivation {
     pname = "apalache";
     inherit version;
 

--- a/resources/apalache.nix
+++ b/resources/apalache.nix
@@ -32,7 +32,7 @@ in
     pname = "apalache";
     inherit version;
 
-    depsSha256 = "sha256-9wGlIFmvKW4N8NQqhOlxjhl48JptHCSI8F8EFF9mYrw=";
+    depsSha256 = "sha256-Fyf98HRE5zzSD3aMDsNb6bJh2Ml6DC4+BqH+a7ljFHo=";
 
     src = apalache-src;
 

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -70,4 +70,16 @@ in
         doCheck = false;
         excludedPackages = ["./e2e"];
       };
+
+      ibc-go-sdk-50-simapp = {
+        name = "simd";
+        version = "v8.0.0-pre.sdk-50";
+        src = inputs.ibc-go-sdk-50-src;
+        vendorSha256 = "sha256-jm/stpw2DqXzlPoNUhem8lwdIHJRf5eP282PtExfWzs=";
+        goVersion = "1.20";
+        tags = ["netgo"];
+        engine = "cometbft/cometbft";
+        doCheck = false;
+        excludedPackages = ["./e2e"];
+      };
     }

--- a/resources/utilities.nix
+++ b/resources/utilities.nix
@@ -11,6 +11,7 @@
     additionalLdFlags ? "",
     appName ? null,
     preCheck ? null,
+    goVersion ? "1.19",
     ...
   }: let
     buildGoModuleArgs =
@@ -43,8 +44,16 @@
       if appName == null
       then "${name}d"
       else appName;
+
+    buildGoModuleVersion = {
+      "1.19" = pkgs.buildGo119Module;
+      "1.20" = pkgs.buildGo120Module;
+      "1.21" = pkgs.buildGo121Module;
+    };
+
+    buildGoModule = buildGoModuleVersion.${goVersion};
   in
-    pkgs.buildGo119Module ({
+    buildGoModule ({
         inherit version src vendorSha256;
         pname = name;
         preCheck =


### PR DESCRIPTION
Not for merge, only testing for now.

Had to update the flake inputs to get Go 1.20 final instead of pre-release, but had to remove old packages whose source can't be found anymore for it to work.