### PR TITLE
Update ibc-go v8.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,16 +583,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695930850,
-        "narHash": "sha256-BHmsnnqB+SoS8UdfGbEk07EXGZJG9ELo4+2gAbP8LdM=",
+        "lastModified": 1699602904,
+        "narHash": "sha256-BcP3y874QviVsV+04p9CioolyvmWH82ORbb5EB2GyRI=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "9c7212198d0ef82b8219ea66cee9c96b40e7981d",
+        "rev": "2551dea41cd3c512845007ca895c8402afa9b79f",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.0.0-beta.1",
+        "ref": "v8.0.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
     ibc-go-v7-src.url = github:cosmos/ibc-go/v7.3.0;
 
     ibc-go-v8-src.flake = false;
-    ibc-go-v8-src.url = github:cosmos/ibc-go/v8.0.0-beta.1;
+    ibc-go-v8-src.url = github:cosmos/ibc-go/v8.0.0;
 
     ibc-go-v8-channel-upgrade-src.flake = false;
     ibc-go-v8-channel-upgrade-src.url = github:cosmos/ibc-go/04-channel-upgrades-alpha.0;

--- a/resources/ibc-go/default.nix
+++ b/resources/ibc-go/default.nix
@@ -78,9 +78,9 @@ in
       # the given subdirectory as source
       ibc-go-v8-simapp = {
         name = "simd";
-        version = "v8.0.0-beta.1";
+        version = "v8.0.0";
         src = inputs.ibc-go-v8-src;
-        vendorSha256 = "sha256-vUj5rwsA7RQfip/LktWG+MdazYfux6zpFN7L/AGdHo0=";
+        vendorSha256 = "sha256-XlbW/4KIzWhdwXR6/oZ/wLbm76BcszbHibGNuxvgCAE=";
         goVersion = "1.21";
         tags = ["netgo"];
         engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR updates ibc-go simapp from `v8.0.0-beta.1` to the release `v8.0.0`