### PR TITLE
Update multiple chain versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     "celestia-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1697229641,
-        "narHash": "sha256-1HvYCZEcB7BCY5q9ykEZuCMzqcbA3JoDMwoHVJ0+SaY=",
+        "lastModified": 1700494564,
+        "narHash": "sha256-O6KrCStrZLmWy3xybQUNsWEb3O7vIRCFDE9MsEtsFro=",
         "owner": "celestiaorg",
         "repo": "celestia-app",
-        "rev": "2b8cc9e23826ccb658b7dd5aa6cd51a0921a0c29",
+        "rev": "2dbfabf1849e166974c1287c35b43e5e07727643",
         "type": "github"
       },
       "original": {
         "owner": "celestiaorg",
-        "ref": "v1.1.0",
+        "ref": "v1.4.0",
         "repo": "celestia-app",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -868,16 +868,16 @@
     "osmosis-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695859760,
-        "narHash": "sha256-Ad2Z4rzD0HQtnj2aQ4GD6ic5sxOHVPsaW4iNKZEDTiw=",
+        "lastModified": 1700576443,
+        "narHash": "sha256-UE3XEgdSp8mlgIKQRrBfb4wiPEeagB/wNWfDvDq4up4=",
         "owner": "osmosis-labs",
         "repo": "osmosis",
-        "rev": "38d1d2b748d161fd23f966d88b23b66a63c9a284",
+        "rev": "d9965b09d3e8690c77050bb095bc5b69772ebdfb",
         "type": "github"
       },
       "original": {
         "owner": "osmosis-labs",
-        "ref": "v19.2.0",
+        "ref": "v20.4.0",
         "repo": "osmosis",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -772,16 +772,16 @@
     "neutron-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685114240,
-        "narHash": "sha256-xHi4W4fOT3kTmkPEKdGp6JbzKQELdWy9PIn0qsZhprY=",
+        "lastModified": 1689686537,
+        "narHash": "sha256-JnGovejgL+dEiZupzS+tPaUl2br4eGntiEfMKGUPEps=",
         "owner": "neutron-org",
         "repo": "neutron",
-        "rev": "3c8dde1ff524551e24295d393a3913c25199d265",
+        "rev": "780486095bf657f7b94b4474cb39fd137cf93c98",
         "type": "github"
       },
       "original": {
         "owner": "neutron-org",
-        "ref": "v1.0.2",
+        "ref": "v1.0.4",
         "repo": "neutron",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -755,16 +755,16 @@
     "migaloo-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681833529,
-        "narHash": "sha256-7sOAcUcc1HpZgLjjdiNuXeXCq9vB9EXCMY4YIT1MAgU=",
+        "lastModified": 1699273936,
+        "narHash": "sha256-O+vGWFnV3+bvXinxl1QjVyDnQskp5H1VnlL+TaMfiSs=",
         "owner": "White-Whale-Defi-Platform",
         "repo": "migaloo-chain",
-        "rev": "129e6fecd377614123f2af33417f9e31accf195f",
+        "rev": "de98de2dd96917ae1ab79161d573fc0b4ee1facf",
         "type": "github"
       },
       "original": {
         "owner": "White-Whale-Defi-Platform",
-        "ref": "v2.0.2",
+        "ref": "v3.0.2",
         "repo": "migaloo-chain",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@
     celestia-src.url = github:celestiaorg/celestia-app/v1.1.0;
 
     neutron-src.flake = false;
-    neutron-src.url = github:neutron-org/neutron/v1.0.2;
+    neutron-src.url = github:neutron-org/neutron/v1.0.4;
 
     gex-src.flake = false;
     gex-src.url = github:cosmos/gex/bc168741b2019745d343606d31b5c274f216fc3f;

--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,7 @@
     stride-consumer-src.url = github:Stride-Labs/stride/v12.1.0;
 
     migaloo-src.flake = false;
-    migaloo-src.url = github:White-Whale-Defi-Platform/migaloo-chain/v2.0.2;
+    migaloo-src.url = github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2;
 
     celestia-src.flake = false;
     celestia-src.url = github:celestiaorg/celestia-app/v1.1.0;

--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
     juno-src.url = github:CosmosContracts/juno/v13.0.1;
 
     osmosis-src.flake = false;
-    osmosis-src.url = github:osmosis-labs/osmosis/v19.2.0;
+    osmosis-src.url = github:osmosis-labs/osmosis/v20.4.0;
 
     sentinel-src.flake = false;
     sentinel-src.url = github:sentinel-official/hub/v0.9.0-rc0;

--- a/flake.nix
+++ b/flake.nix
@@ -197,7 +197,7 @@
     migaloo-src.url = github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2;
 
     celestia-src.flake = false;
-    celestia-src.url = github:celestiaorg/celestia-app/v1.1.0;
+    celestia-src.url = github:celestiaorg/celestia-app/v1.4.0;
 
     neutron-src.flake = false;
     neutron-src.url = github:neutron-org/neutron/v1.0.4;

--- a/resources.nix
+++ b/resources.nix
@@ -322,9 +322,9 @@
 
       migaloo = utilities.mkCosmosGoApp {
         name = "migaloo";
-        version = "v2.0.2";
+        version = "v3.0.2";
         src = inputs.migaloo-src;
-        vendorSha256 = "sha256-Z85OpuiB73BHSSuPADvE3tJ5ZstHYik8yghfCHXy3W0=";
+        vendorSha256 = "sha256-GQDfI4hSkkrsBfIczdGoOhghR7/FqEvXavyP4E6iHM4=";
         engine = "tendermint/tendermint";
         preFixup = ''
           ${utilities.wasmdPreFixupPhase libwasmvm_1_2_3 "migalood"}

--- a/resources.nix
+++ b/resources.nix
@@ -345,9 +345,9 @@
 
       neutron = utilities.mkCosmosGoApp {
         name = "neutron";
-        version = "v1.0.2";
+        version = "v1.0.4";
         src = inputs.neutron-src;
-        vendorSha256 = "sha256-Q3QEk7qS1ue/HrvwdkGh6iX8BTg+0ssznyWsYtzZ+/4=";
+        vendorSha256 = "sha256-jlzFYx09U7BkBg9LDZqfwT4aASQSbuVBl0a/WCrly8A=";
         engine = "tendermint/tendermint";
         preFixup = ''
           ${utilities.wasmdPreFixupPhase libwasmvm_1_2_3 "neutrond"}

--- a/resources.nix
+++ b/resources.nix
@@ -334,10 +334,10 @@
 
       celestia = utilities.mkCosmosGoApp {
         name = "celestia";
-        version = "v1.1.0";
+        version = "v1.4.0";
         src = inputs.celestia-src;
         goVersion = "1.21";
-        vendorSha256 = "sha256-XA43E8EWTSdBKB1J2tf/11MfByDXHSdNBXcM6q06kj8=";
+        vendorSha256 = "sha256-KvkVqJZ5kvkKWXTYgG7+Ksz8aLhGZPBG5zkM44fVNT4=";
         engine = "tendermint/tendermint";
 
         doCheck = false;

--- a/resources.nix
+++ b/resources.nix
@@ -116,9 +116,9 @@
 
       osmosis = utilities.mkCosmosGoApp {
         name = "osmosis";
-        version = "v19.2.0";
+        version = "v20.4.0";
         src = inputs.osmosis-src;
-        vendorSha256 = "sha256-z1lGckpsrCui8VQow3ciy6yl5LL5NxHMIU+SGL9wvKs=";
+        vendorSha256 = "sha256-WN6H+lRS+wX4CiVEVMxp4fW2vtZxTi+O6SncJdrUFLo=";
         tags = ["netgo"];
         excludedPackages = ["cl-genesis-positions"];
         engine = "tendermint/tendermint";


### PR DESCRIPTION
This PR updates the following chain versions:

* Osmosis from `v19.2.0` to `v20.4.0`
* Neutron from `v1.0.2` to `v1.0.4`
* Migaloo from `v2.0.2` to `v3.0.2`
* Osmosis from `v1.0.1` to `v1.0.4`