### PR TITLE
Update channel upgrade tag from alpha to rc.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -635,16 +635,16 @@
     "ibc-go-v8-channel-upgrade-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695726576,
-        "narHash": "sha256-mM6h1KAi8lQUrJakxI6f8WI+vpmBhCnAysk3hTZBI7M=",
+        "lastModified": 1703189903,
+        "narHash": "sha256-vxzv+b40TKqCIN4FAkeIu+jmlPP5XRLR+P0uEIjr7AE=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "63c30108f0ecf954108cf51f50f3d36ec58c7e51",
+        "rev": "7a89e5d5b5ebb7643ce3992c34008c35373ecf34",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "04-channel-upgrades-alpha.0",
+        "ref": "04-channel-upgrades-rc.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
     ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.0.0";
     ibc-go-v8-src.flake = false;
 
-    ibc-go-v8-channel-upgrade-src.url = "github:cosmos/ibc-go/04-channel-upgrades-alpha.0";
+    ibc-go-v8-channel-upgrade-src.url = "github:cosmos/ibc-go/04-channel-upgrades-rc.0";
     ibc-go-v8-channel-upgrade-src.flake = false;
 
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -91,10 +91,10 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-channel-upgrade-simapp = {
       name = "simd";
-      version = "channel-upgrade-alpha.0";
+      version = "channel-upgrade-rc.0";
       src = ibc-go-v8-channel-upgrade-src;
       rev = ibc-go-v8-channel-upgrade-src.rev;
-      vendorHash = "sha256-FOCQcn9r7mmpjY9h4gvwcRqL4qhu3wkXsx1KM1n17Cg=";
+      vendorHash = "sha256-XlbW/4KIzWhdwXR6/oZ/wLbm76BcszbHibGNuxvgCAE=";
       goVersion = "1.21";
       tags = ["netgo"];
       engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR update the tag used for simapp channel upgrade from alpha to rc.0