### PR TITLE
Update simapp from v8.0.0 to v8.1.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,16 +652,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1706086871,
-        "narHash": "sha256-n9yshPUw2RYpcnO7yDgO5Pq0xyf2m305q6myjJ8PJlg=",
+        "lastModified": 1706691043,
+        "narHash": "sha256-eS+X4bT7vp1+LyIPd0mOnAJahAONr+Syton3v3rSkGI=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "e638546626361e83cdb75a5307e929fea551d36a",
+        "rev": "7e01c9149149b9d4b1d871e58eb88a22f15bdb3c",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.1.0-rc.0",
+        "ref": "v8.1.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -652,16 +652,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1699602904,
-        "narHash": "sha256-BcP3y874QviVsV+04p9CioolyvmWH82ORbb5EB2GyRI=",
+        "lastModified": 1706086871,
+        "narHash": "sha256-n9yshPUw2RYpcnO7yDgO5Pq0xyf2m305q6myjJ8PJlg=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "2551dea41cd3c512845007ca895c8402afa9b79f",
+        "rev": "e638546626361e83cdb75a5307e929fea551d36a",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.0.0",
+        "ref": "v8.1.0-rc.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -632,23 +632,6 @@
         "type": "github"
       }
     },
-    "ibc-go-v8-channel-upgrade-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705917317,
-        "narHash": "sha256-o+dg+AjhzRPKcv+gbIV01qqFfuwsTRDXc2oBG7KuENQ=",
-        "owner": "cosmos",
-        "repo": "ibc-go",
-        "rev": "4e3d164e4f9a5986bbe6595138feb49160e27215",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cosmos",
-        "ref": "04-channel-upgrades-hermes-integration.1",
-        "repo": "ibc-go",
-        "type": "github"
-      }
-    },
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
@@ -1036,7 +1019,6 @@
         "ibc-go-v5-src": "ibc-go-v5-src",
         "ibc-go-v6-src": "ibc-go-v6-src",
         "ibc-go-v7-src": "ibc-go-v7-src",
-        "ibc-go-v8-channel-upgrade-src": "ibc-go-v8-channel-upgrade-src",
         "ibc-go-v8-src": "ibc-go-v8-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
     ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.3.0";
     ibc-go-v7-src.flake = false;
 
-    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.0.0";
+    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.1.0-rc.0";
     ibc-go-v8-src.flake = false;
 
     ibc-go-v8-channel-upgrade-src.url = "github:cosmos/ibc-go/04-channel-upgrades-hermes-integration.1";

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
     ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.3.0";
     ibc-go-v7-src.flake = false;
 
-    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.1.0-rc.0";
+    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.1.0";
     ibc-go-v8-src.flake = false;
 
     ibc-go-v8-channel-upgrade-src.url = "github:cosmos/ibc-go/04-channel-upgrades-hermes-integration.1";

--- a/flake.nix
+++ b/flake.nix
@@ -125,9 +125,6 @@
     ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.1.0";
     ibc-go-v8-src.flake = false;
 
-    ibc-go-v8-channel-upgrade-src.url = "github:cosmos/ibc-go/04-channel-upgrades-hermes-integration.1";
-    ibc-go-v8-channel-upgrade-src.flake = false;
-
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";
     cosmos-sdk-src.flake = false;
 

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -76,7 +76,7 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-simapp = {
       name = "simd";
-      version = "v8.1.0-rc.0";
+      version = "v8.1.0";
       src = ibc-go-v8-src;
       rev = ibc-go-v8-src.rev;
       vendorHash = "sha256-KmuidyqJXwZOg+cnas/5O6awcKeEgzsByDg9rClADUQ=";

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -85,19 +85,4 @@ with inputs;
       engine = "cometbft/cometbft";
       excludedPackages = ["./e2e" "./modules/apps/callbacks" "./modules/capability"];
     };
-
-    # If the modules/apps/callbacks and/or modules/capability are needed,
-    # they must each be defined in a separate nix package that loads only
-    # the given subdirectory as source
-    ibc-go-v8-channel-upgrade-simapp = {
-      name = "simd";
-      version = "channel-upgrades-hermes-integration.1";
-      src = ibc-go-v8-channel-upgrade-src;
-      rev = ibc-go-v8-channel-upgrade-src.rev;
-      vendorHash = "sha256-BLwp9TrvFRH1XHh9XeaeqhB+HkHW9RMxg8bHmG6dxg4=";
-      goVersion = "1.21";
-      tags = ["netgo"];
-      engine = "cometbft/cometbft";
-      excludedPackages = ["./e2e" "./modules/apps/callbacks" "./modules/capability" "./modules/light-clients/08-wasm"];
-    };
   }

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -76,10 +76,10 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-simapp = {
       name = "simd";
-      version = "v8.0.0";
+      version = "v8.1.0-rc.0";
       src = ibc-go-v8-src;
       rev = ibc-go-v8-src.rev;
-      vendorHash = "sha256-XlbW/4KIzWhdwXR6/oZ/wLbm76BcszbHibGNuxvgCAE=";
+      vendorHash = "sha256-KmuidyqJXwZOg+cnas/5O6awcKeEgzsByDg9rClADUQ=";
       goVersion = "1.21";
       tags = ["netgo"];
       engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR updates ibc-go v8 simapp from v8.0.0 to v8.1.0
Since the v8.1.0 has the channel upgrade feature, it also removes the `ibc-go-v8-channel-upgrade-simapp`