### PR TITLE
celestia-node: init at v0.13.0, rename old `celestia` to `celestia-app`, add `celestia` combined pkg

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,6 +51,23 @@
         "type": "github"
       }
     },
+    "celestia-node-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707218580,
+        "narHash": "sha256-O5a8Dy7WOSaLzYHTZAZFHFeJwqOLyajcHmGEcphOpKg=",
+        "owner": "celestiaorg",
+        "repo": "celestia-node",
+        "rev": "e55e1c88708b46839867bcbbed9bcdd8a3ffa830",
+        "type": "github"
+      },
+      "original": {
+        "owner": "celestiaorg",
+        "ref": "v0.13.0",
+        "repo": "celestia-node",
+        "type": "github"
+      }
+    },
     "celestia-src": {
       "flake": false,
       "locked": {
@@ -1269,6 +1286,7 @@
         "akash-src": "akash-src",
         "apalache-src": "apalache-src",
         "beaker-src": "beaker-src",
+        "celestia-node-src": "celestia-node-src",
         "celestia-src": "celestia-src",
         "centauri-src": "centauri-src",
         "cometbft-src": "cometbft-src",

--- a/flake.lock
+++ b/flake.lock
@@ -51,6 +51,23 @@
         "type": "github"
       }
     },
+    "celestia-app-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700494564,
+        "narHash": "sha256-O6KrCStrZLmWy3xybQUNsWEb3O7vIRCFDE9MsEtsFro=",
+        "owner": "celestiaorg",
+        "repo": "celestia-app",
+        "rev": "2dbfabf1849e166974c1287c35b43e5e07727643",
+        "type": "github"
+      },
+      "original": {
+        "owner": "celestiaorg",
+        "ref": "v1.4.0",
+        "repo": "celestia-app",
+        "type": "github"
+      }
+    },
     "celestia-node-src": {
       "flake": false,
       "locked": {
@@ -65,23 +82,6 @@
         "owner": "celestiaorg",
         "ref": "v0.13.0",
         "repo": "celestia-node",
-        "type": "github"
-      }
-    },
-    "celestia-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1700494564,
-        "narHash": "sha256-O6KrCStrZLmWy3xybQUNsWEb3O7vIRCFDE9MsEtsFro=",
-        "owner": "celestiaorg",
-        "repo": "celestia-app",
-        "rev": "2dbfabf1849e166974c1287c35b43e5e07727643",
-        "type": "github"
-      },
-      "original": {
-        "owner": "celestiaorg",
-        "ref": "v1.4.0",
-        "repo": "celestia-app",
         "type": "github"
       }
     },
@@ -1286,8 +1286,8 @@
         "akash-src": "akash-src",
         "apalache-src": "apalache-src",
         "beaker-src": "beaker-src",
+        "celestia-app-src": "celestia-app-src",
         "celestia-node-src": "celestia-node-src",
-        "celestia-src": "celestia-src",
         "centauri-src": "centauri-src",
         "cometbft-src": "cometbft-src",
         "cosmos-sdk-src": "cosmos-sdk-src",

--- a/flake.nix
+++ b/flake.nix
@@ -218,8 +218,8 @@
     migaloo-src.url = "github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2";
     migaloo-src.flake = false;
 
-    celestia-src.url = "github:celestiaorg/celestia-app/v1.4.0";
-    celestia-src.flake = false;
+    celestia-app-src.url = "github:celestiaorg/celestia-app/v1.4.0";
+    celestia-app-src.flake = false;
 
     celestia-node-src.url = "github:celestiaorg/celestia-node/v0.13.0";
     celestia-node-src.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -221,6 +221,9 @@
     celestia-src.url = "github:celestiaorg/celestia-app/v1.4.0";
     celestia-src.flake = false;
 
+    celestia-node-src.url = "github:celestiaorg/celestia-node/v0.13.0";
+    celestia-node-src.flake = false;
+
     neutron-src.url = "github:neutron-org/neutron/v2.0.0";
     neutron-src.flake = false;
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -192,7 +192,7 @@
           type = "app";
           program = "${packages.migaloo}/bin/migalood";
         };
-        celestia = {
+        celestia-app = {
           type = "app";
           program = "${packages.celestia}/bin/celestia-appd";
         };

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -196,6 +196,10 @@
           type = "app";
           program = "${packages.celestia}/bin/celestia-appd";
         };
+        celestia-node = {
+          type = "app";
+          program = "${packages.celestia-node}/bin/celestia";
+        };
         provenance = {
           type = "app";
           program = "${packages.provenance}/bin/provenanced";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -26,6 +26,10 @@
           inherit (inputs) celestia-src;
           inherit (cosmosLib) mkCosmosGoApp;
         };
+        celestia-node = import ../packages/celestia-node.nix {
+          inherit (inputs) celestia-node-src;
+          inherit (cosmosLib) mkCosmosGoApp;
+        };
         centauri = import ../packages/centauri.nix {
           inherit (inputs) centauri-src;
           inherit (self'.packages) libwasmvm_1_2_4;

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -22,13 +22,17 @@
           inherit pkgs;
           inherit (inputs) beaker-src;
         };
-        celestia = import ../packages/celestia.nix {
-          inherit (inputs) celestia-src;
+        celestia-app = import ../packages/celestia-app.nix {
+          inherit (inputs) celestia-app-src;
           inherit (cosmosLib) mkCosmosGoApp;
         };
         celestia-node = import ../packages/celestia-node.nix {
           inherit (inputs) celestia-node-src;
           inherit (cosmosLib) mkCosmosGoApp;
+        };
+        celestia = pkgs.symlinkJoin {
+          name = "celestia";
+          paths = [self'.packages.celestia-app self'.packages.celestia-node];
         };
         centauri = import ../packages/centauri.nix {
           inherit (inputs) centauri-src;

--- a/packages/celestia-app.nix
+++ b/packages/celestia-app.nix
@@ -1,12 +1,12 @@
 {
-  celestia-src,
+  celestia-app-src,
   mkCosmosGoApp,
 }:
 mkCosmosGoApp {
-  name = "celestia";
+  name = "celestia-app";
   version = "v1.4.0";
-  src = celestia-src;
-  rev = celestia-src.rev;
+  src = celestia-app-src;
+  rev = celestia-app-src.rev;
   goVersion = "1.21";
   vendorHash = "sha256-KvkVqJZ5kvkKWXTYgG7+Ksz8aLhGZPBG5zkM44fVNT4=";
   engine = "tendermint/tendermint";

--- a/packages/celestia-node.nix
+++ b/packages/celestia-node.nix
@@ -1,0 +1,14 @@
+{
+  celestia-node-src,
+  mkCosmosGoApp,
+}:
+mkCosmosGoApp {
+  name = "celestia-node";
+  version = "v0.13.0";
+  src = celestia-node-src;
+  rev = celestia-node-src.rev;
+  goVersion = "1.21";
+  vendorHash = "sha256-wUyb6gZ9n+wOBagJ1BdKcbBGtLIaVyaRH6NHSJ7VFk8=";
+  engine = "tendermint/tendermint";
+  doCheck = false;
+}


### PR DESCRIPTION
This adds the `celestia-node` package, i.e. celestia's Data Availability node (as opposed to the already included `celestia` package which is actually `celestia-app`, the consensus node).

This also changes the name of the existing `celestia` package to `celestia-app` to better match the documentation and its `celestia-appd` binary, and to reduce confusion around the `celestia` binary which is actually included with the `celestia-node` package.

A wrapper `celestia` package has been included that wraps the `celestia-app` and `celestia-node` packages under a single `celestia` package using `symlinkJoin`. As a result, building `celestia` now produces the same binaries that it used to (`celestia-appd`) while also providing the actual `celestia` binary from the `celestia-node` package.

Here's what the `result` of building the `celestia` package looks like now:

```console
$ tree result
result
└── bin
    ├── celestia -> /nix/store/577hnx648wn5mb0bxs8k36pzz6hip4kk-celestia-node-v0.13.0/bin/celestia
    ├── celestia-appd -> /nix/store/br3s6pqima4vl5z3qshp3p6xd4fwdf81-celestia-app-v1.4.0/bin/celestia-appd
    ├── cel-key -> /nix/store/577hnx648wn5mb0bxs8k36pzz6hip4kk-celestia-node-v0.13.0/bin/cel-key
    ├── cel-shed -> /nix/store/577hnx648wn5mb0bxs8k36pzz6hip4kk-celestia-node-v0.13.0/bin/cel-shed
    ├── docgen -> /nix/store/577hnx648wn5mb0bxs8k36pzz6hip4kk-celestia-node-v0.13.0/bin/docgen
    ├── e2e -> /nix/store/br3s6pqima4vl5z3qshp3p6xd4fwdf81-celestia-app-v1.4.0/bin/e2e
    └── txsim -> /nix/store/br3s6pqima4vl5z3qshp3p6xd4fwdf81-celestia-app-v1.4.0/bin/txsim
```

You can find the quickstart explanation for the distinction between celestia-node and celestia-app here: https://docs.celestia.org/nodes/quick-start