### PR TITLE
Add Rollapp EVM

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1298,6 +1298,23 @@
         "type": "github"
       }
     },
+    "rollapp-evm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710268992,
+        "narHash": "sha256-bOH7QsNYjZVVHW7x5ysrO0IJmRNEUeE+bJRVPwdb5U8=",
+        "owner": "dymensionxyz",
+        "repo": "rollapp-evm",
+        "rev": "21b29f6e77f5c11a2036252d60819810abbbd7b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dymensionxyz",
+        "repo": "rollapp-evm",
+        "rev": "21b29f6e77f5c11a2036252d60819810abbbd7b8",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "akash-src": "akash-src",
@@ -1354,6 +1371,7 @@
         "provenance-src": "provenance-src",
         "regen-src": "regen-src",
         "relayer-src": "relayer-src",
+        "rollapp-evm-src": "rollapp-evm-src",
         "rust-overlay": "rust-overlay",
         "sbt-derivation": "sbt-derivation",
         "sconfig-src": "sconfig-src",

--- a/flake.nix
+++ b/flake.nix
@@ -251,6 +251,9 @@
     slinky-src.url = "github:skip-mev/slinky/v0.2.0";
     slinky-src.flake = false;
 
+    rollapp-evm-src.url = "github:dymensionxyz/rollapp-evm/21b29f6e77f5c11a2036252d60819810abbbd7b8";
+    rollapp-evm-src.flake = false;
+
     haqq-src.url = "github:haqq-network/haqq/18370cfb2f9aab35d311c4c75ab5586f50213830";
   };
 }

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -154,6 +154,10 @@
           inherit (self'.packages) libwasmvm_1_2_3;
           inherit cosmosLib;
         };
+        rollapp-evm = import ../packages/rollapp-evm.nix {
+          inherit (cosmosLib) mkCosmosGoApp;
+          inherit (inputs) rollapp-evm-src;
+        };
       }
       # This list contains attr sets that are recursively merged into the
       # base attrset

--- a/packages/rollapp-evm.nix
+++ b/packages/rollapp-evm.nix
@@ -7,9 +7,8 @@ mkCosmosGoApp {
   version = "v2.0.0-beta-7-g21b29f6";
   src = "${rollapp-evm-src}";
   rev = rollapp-evm-src.rev;
-  vendorHash = "sha256-2mDEDtFN0T6430owWxPl+zLl/BaJaNDMA//RUBtncbs=";
+  vendorHash = "sha256-rg3ZrNIMuUUW01lyjklTxn4zYlOiwFXyTqSE7scaRAk=";
   tags = ["netgo"];
-  goVersion = "1.21";
+  goVersion = "1.20";
   engine = "cometbft/cometbft";
-  doCheck = false;
 }

--- a/packages/rollapp-evm.nix
+++ b/packages/rollapp-evm.nix
@@ -5,7 +5,7 @@
 mkCosmosGoApp {
   name = "rollapp-evm";
   version = "v2.0.0-beta-7-g21b29f6";
-  src = "${rollapp-evm-src}";
+  src = rollapp-evm-src;
   rev = rollapp-evm-src.rev;
   vendorHash = "sha256-rg3ZrNIMuUUW01lyjklTxn4zYlOiwFXyTqSE7scaRAk=";
   tags = ["netgo"];

--- a/packages/rollapp-evm.nix
+++ b/packages/rollapp-evm.nix
@@ -1,0 +1,15 @@
+{
+  mkCosmosGoApp,
+  rollapp-evm-src,
+}:
+mkCosmosGoApp {
+  name = "rollapp-evm";
+  version = "v2.0.0-beta-7-g21b29f6";
+  src = "${rollapp-evm-src}";
+  rev = rollapp-evm-src.rev;
+  vendorHash = "sha256-2mDEDtFN0T6430owWxPl+zLl/BaJaNDMA//RUBtncbs=";
+  tags = ["netgo"];
+  goVersion = "1.21";
+  engine = "cometbft/cometbft";
+  doCheck = false;
+}


### PR DESCRIPTION
Currently fails with

```
❯ nix shell '.#rollapp-evm'
error: builder for '/nix/store/lgm1ayp1m9hhxpjvmjsicv7gri7n854a-rollapp-evm-v2.0.0-beta-7-g21b29f6-go-modules.drv' failed with exit code 1;
       last 10 log lines:
       > go: downloading github.com/go-logr/logr v1.2.4
       > go: downloading github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
       > go: downloading github.com/google/s2a-go v0.1.7
       > go: downloading github.com/googleapis/enterprise-certificate-proxy v0.3.2
       > go: downloading github.com/go-logr/stdr v1.2.2
       > go: downloading github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e
       > go: downloading github.com/ghodss/yaml v1.0.0
       > go: downloading github.com/blang/semver v3.5.1+incompatible
       > go: updates to go.mod needed; to update it:
       >   go mod tidy
       For full logs, run 'nix log /nix/store/lgm1ayp1m9hhxpjvmjsicv7gri7n854a-rollapp-evm-v2.0.0-beta-7-g21b29f6-go-modules.drv'.
error: 1 dependencies of derivation '/nix/store/fsd8q6wbw9s81px5ln0p41g1064lk24l-rollapp-evm-v2.0.0-beta-7-g21b29f6.drv' failed to build
```

Haven't found a way to run `go mod tidy` at a pre-build step yet.