### PR TITLE
Update ibc-go versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -727,15 +727,16 @@
     "ibc-go-v4-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-R1/AH6laXdaMftgwnV4t/pL3QoKnZ1UaBGoqOipOvQI=",
+        "lastModified": 1712304740,
+        "narHash": "sha256-CNv3uBCALT21ZczOmXcQaavOy7KsR0VTBahw5DrvO4w=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "ecb845d5e43f53decf48f8ed88c7847a9a4375cb",
+        "rev": "5480cf7fac99882a8833ddb7c95e8b4820ab7d4f",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v4.2.0",
+        "ref": "v4.6.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -743,15 +744,16 @@
     "ibc-go-v5-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-+Z78PyGODLr2Y5G8evubsoQE3tyUcxCHJDsLXKTmdlI=",
+        "lastModified": 1712304845,
+        "narHash": "sha256-CE6Nv6U3Jqn4c+5JB/rek9LHD+AXEnkS0FVJYz4/uSc=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "c0acd5bd1778f2b7ecdf593006f56bd3e273bd49",
+        "rev": "40cacfe075947f21520b014294f1f7948e4eda7c",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v5.1.0",
+        "ref": "v5.4.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -759,15 +761,16 @@
     "ibc-go-v6-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-V8kUNwgNfx1tZJazlnaTF6wBb7ztueh1KrAGgiP8hCM=",
+        "lastModified": 1712318519,
+        "narHash": "sha256-roRXZEOJIFJiXEQ+a71QdMmqoVJKVk2wvPgHJ9r/mQ8=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "d34cef7e075dda1a24a0a3e9b6d3eff406cc606c",
+        "rev": "8e31269c692d87ac65bfe70cf609925975a57203",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v6.1.0",
+        "ref": "v6.3.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -775,15 +778,16 @@
     "ibc-go-v7-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-umh/ckDALt0ugXwN8glcaCkGfAQvXY7S3Jd95Do2XeA=",
+        "lastModified": 1712318559,
+        "narHash": "sha256-uYiUNXLD48v3vRGK6/aQ7z7Ed5hY8VnEBGG/3Uv87Nc=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "c75650a1a037a9fecba5a9005df380f707520ff7",
+        "rev": "802ca265dba74a293747e1ccb8b7999aa985af19",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.3.0",
+        "ref": "v7.4.0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -791,15 +795,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-eS+X4bT7vp1+LyIPd0mOnAJahAONr+Syton3v3rSkGI=",
+        "lastModified": 1712305073,
+        "narHash": "sha256-J/tuv2U6cW+y51gUi4aXzR39lJD/8J/36lf7h2242sU=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "7e01c9149149b9d4b1d871e58eb88a22f15bdb3c",
+        "rev": "a2f3d7a78d21641178043341de96c3ecf06fa47b",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.1.0",
+        "ref": "v8.2.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -116,19 +116,19 @@
     ibc-go-v3-src.url = "github:cosmos/ibc-go/v3.3.0";
     ibc-go-v3-src.flake = false;
 
-    ibc-go-v4-src.url = "github:cosmos/ibc-go/v4.2.0";
+    ibc-go-v4-src.url = "github:cosmos/ibc-go/v4.6.0";
     ibc-go-v4-src.flake = false;
 
-    ibc-go-v5-src.url = "github:cosmos/ibc-go/v5.1.0";
+    ibc-go-v5-src.url = "github:cosmos/ibc-go/v5.4.0";
     ibc-go-v5-src.flake = false;
 
-    ibc-go-v6-src.url = "github:cosmos/ibc-go/v6.1.0";
+    ibc-go-v6-src.url = "github:cosmos/ibc-go/v6.3.0";
     ibc-go-v6-src.flake = false;
 
-    ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.3.0";
+    ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.4.0";
     ibc-go-v7-src.flake = false;
 
-    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.1.0";
+    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.2.0";
     ibc-go-v8-src.flake = false;
 
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -27,20 +27,20 @@ with inputs;
 
     ibc-go-v4-simapp = {
       name = "simapp";
-      version = "v4.2.0";
+      version = "v4.6.0";
       src = ibc-go-v4-src;
       rev = ibc-go-v4-src.rev;
-      vendorHash = "sha256-M8N6IPBnhOQp4LsCgdKc0NOtdeLNkAcXtGsvHS00D+g=";
+      vendorHash = "sha256-1BrGCK/TtJFEvHf7C7OXvwNRxeCJejM17Jq7a3JVlnk=";
       tags = ["netgo"];
       engine = "tendermint/tendermint";
     };
 
     ibc-go-v5-simapp = {
       name = "simapp";
-      version = "v5.1.0";
+      version = "v5.4.0";
       src = ibc-go-v5-src;
       rev = ibc-go-v5-src.rev;
-      vendorHash = "sha256-KajTi+hCMM8AoLsGmWV7qVGbYA8vZhn+0tmG20zJgPI=";
+      vendorHash = "sha256-k1YaGedNUv1fjXNfYjDAfcX8KqviHhWFreqjYHXQoJs=";
       tags = ["netgo"];
       engine = "tendermint/tendermint";
       excludedPackages = ["./e2e"];
@@ -48,10 +48,10 @@ with inputs;
 
     ibc-go-v6-simapp = {
       name = "simapp";
-      version = "v6.1.0";
+      version = "v6.3.0";
       src = ibc-go-v6-src;
       rev = ibc-go-v6-src.rev;
-      vendorHash = "sha256-hP/DTNkB1NI7yZZDn5tYy/9jYIb3BqESxIG2A4wgjJU";
+      vendorHash = "sha256-IA6W9MaiDi/4wPDXIVO/6xPJwduBwgLiq/yv1zHFBMc=";
       tags = ["netgo"];
       engine = "tendermint/tendermint";
       excludedPackages = ["./e2e"];
@@ -61,10 +61,10 @@ with inputs;
     # package that loads only the given subdirectory as source
     ibc-go-v7-simapp = {
       name = "simd";
-      version = "v7.3.0";
+      version = "v7.4.0";
       src = ibc-go-v7-src;
       rev = ibc-go-v7-src.rev;
-      vendorHash = "sha256-Wn7krfvF7E93g4KnGZ8iXaSjc+kmGgQ8Jb5egWNMQg8=";
+      vendorHash = "sha256-zjk/75+e/gWSCvpz7lrZkNEDigC/x8czpCSxxbSmWXg=";
       goVersion = "1.20";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
@@ -76,10 +76,10 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-simapp = {
       name = "simd";
-      version = "v8.1.0";
+      version = "v8.2.0";
       src = ibc-go-v8-src;
       rev = ibc-go-v8-src.rev;
-      vendorHash = "sha256-KmuidyqJXwZOg+cnas/5O6awcKeEgzsByDg9rClADUQ=";
+      vendorHash = "sha256-a88Eu3Oz5byo03ECaDdUXNGom9F/BsWbCRCI1pkp9yQ=";
       goVersion = "1.21";
       tags = ["netgo"];
       engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR updates the ibc-go versions:

* ibc-go `v4.2.0` -> `v4.6.0`
* ibc-go `v5.1.0` -> `v5.4.0`
* ibc-go `v6.1.0` -> `v6.3.0`
* ibc-go `v7.3.0` -> `v7.4.0`
* ibc-go `v8.1.0` -> `8.2.0`