### PR TITLE
Add sov-celestia wasm contract

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1376,6 +1376,7 @@
         "stride-consumer-src": "stride-consumer-src",
         "stride-src": "stride-src",
         "umee-src": "umee-src",
+        "wasm-sov-celestia-src": "wasm-sov-celestia-src",
         "wasmd-src": "wasmd-src",
         "wasmd_next-src": "wasmd_next-src",
         "wasmvm_1-src": "wasmvm_1-src",
@@ -1638,6 +1639,22 @@
         "owner": "umee-network",
         "ref": "v2.0.0",
         "repo": "umee",
+        "type": "github"
+      }
+    },
+    "wasm-sov-celestia-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712637761,
+        "narHash": "sha256-2pEWcFBBP9J9WLLnXn/M8At+seVyRqH2NBtfgeSynww=",
+        "owner": "informalsystems",
+        "repo": "sovereign-ibc",
+        "rev": "2214dbee441ff005083841f4cd5983229d08d306",
+        "type": "github"
+      },
+      "original": {
+        "owner": "informalsystems",
+        "repo": "sovereign-ibc",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -262,6 +262,8 @@
     # contracts
     cw-plus-src.url = "github:CosmWasm/cw-plus/v1.1.2";
     cw-plus-src.flake = false;
+    wasm-sov-celestia-src.url = "github:informalsystems/sovereign-ibc";
+    wasm-sov-celestia-src.flake = false;
 
     # tools
     beaker-src.url = "github:osmosis-labs/beaker/v0.1.8";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -59,6 +59,10 @@
           inherit (cosmosLib) buildCosmwasmContract;
           inherit (inputs) cw-plus-src;
         };
+        sov-celestia-client-cw = import ../packages/sov-celestia-client-cw.nix {
+          inherit (cosmosLib) buildCosmwasmContract;
+          inherit (inputs) wasm-sov-celestia-src;
+        };
         dydx = import ../packages/dydx.nix {
           inherit (cosmosLib) mkCosmosGoApp;
           inherit (inputs) dydx-src;

--- a/packages/sov-celestia-client-cw.nix
+++ b/packages/sov-celestia-client-cw.nix
@@ -1,0 +1,26 @@
+{
+  buildCosmwasmContract,
+  wasm-sov-celestia-src,
+}:
+buildCosmwasmContract {
+  src = wasm-sov-celestia-src;
+  pname = "sov-celestia-client-cw";
+  name = "sov-celestia-client-cw";
+
+  cargoLock = {
+    lockFile = "${wasm-sov-celestia-src}/Cargo.lock";
+    outputHashes = {
+      "basecoin-0.1.0" = "sha256-3tXSQYGG6K81fxqd8G/5mKT2utqLDS0n0WoZIUbn+og=";
+      "celestia-proto-0.1.0" = "sha256-iUgrctxdJUyhfrEQ0zoVj5AKIqgj/jQVNli5/K2nxK0=";
+      # TODO set correct hash for const-rollup-config
+      "const-rollup-config-0.3.0" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      "ibc-0.51.0" = "sha256-6HcMSTcKx4y1hfKcXnzgiNM9FWdqUuUNnemAgS36Z1A=";
+      "jmt-0.9.0" = "sha256-pq1v6FXS//6Dh+fdysQIVp+RVLHdXrW5aDx3263O1rs=";
+      "nmt-rs-0.1.0" = "sha256-jcHbqyIKk8ZDDjSz+ot5YDxROOnrpM4TRmNFVfNniwU=";
+      "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
+      "rockbound-1.0.0" = "sha256-xTaeBndRb/bYe+tySChDKsh4f9pywAExsdgJExCQiy8=";
+      "sov-celestia-client-0.1.0" = "sha256-9i+CX08AS5r0Z6ggUDDGSl6jiQO9xDTUjIyt2VnAkT0=";
+      "tendermint-0.32.0" = "sha256-FtY7a+hBvQryATrs3mykCWFRe8ABTT6cuf5oh9IBElQ=";
+    };
+  };
+}


### PR DESCRIPTION
This PR adds the sov-celestia wasm contract used for Sovereign clients on Cosmos chains.

### Current state

This PR currently fails due to a dependency being in a private repository