### PR TITLE
Update Osmosis version from v22 to v24 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1199,16 +1199,16 @@
     "osmosis-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1707262742,
-        "narHash": "sha256-DudppJmGaToUcYVbVA17FVXlev1NuoSY+Jy2c7PpZlY=",
+        "lastModified": 1712687434,
+        "narHash": "sha256-j1PtSv4i/3IV6hUHxxgO/5t9/bfWs28i3D/uVAkf68Q=",
         "owner": "osmosis-labs",
         "repo": "osmosis",
-        "rev": "350901e523815fc34a1de1ca54e9ccd3c4d1f756",
+        "rev": "0021d3812a8c8d2798ab17e58991a677b82e8955",
         "type": "github"
       },
       "original": {
         "owner": "osmosis-labs",
-        "ref": "v22.0.5",
+        "ref": "v24.0.1",
         "repo": "osmosis",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
     juno-src.url = "github:CosmosContracts/juno/v17.1.1";
     juno-src.flake = false;
 
-    osmosis-src.url = "github:osmosis-labs/osmosis/v22.0.5";
+    osmosis-src.url = "github:osmosis-labs/osmosis/v24.0.1";
     osmosis-src.flake = false;
 
     sentinel-src.url = "github:sentinel-official/hub/v0.9.0-rc0";

--- a/packages/osmosis.nix
+++ b/packages/osmosis.nix
@@ -5,10 +5,11 @@
 }:
 cosmosLib.mkCosmosGoApp {
   name = "osmosis";
-  version = "v22.0.5";
+  version = "v24.0.1";
+  goVersion = "1.21";
   src = osmosis-src;
   rev = osmosis-src.rev;
-  vendorHash = "sha256-V+5GwiNrZo4f7JtO6r459+5WTImDaqRu2TFIfeSwAjc=";
+  vendorHash = "sha256-RjBnaHKge3b1CwIFUFsyE/Yv83QC8UsGtx87mgI1PPo=";
   tags = ["netgo"];
   excludedPackages = ["cl-genesis-positions"];
   engine = "cometbft/cometbft";


### PR DESCRIPTION
__15.04.2024__

This PR updates Osmosis from v22.0.5 to v24.0.1 which is the latest in https://cosmos.directory/osmosis/chain