### PR TITLE
Update Consumer chains

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1004,15 +1004,16 @@
     "neutron-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-NuoOlrciBeL2f/A7wlQBqYlYJhSYucXRhLgxdasfyhI=",
+        "lastModified": 1712330928,
+        "narHash": "sha256-3olixILNnkRcNwtpPDqQJ63cYjV5qiVYTM+fJEIH65s=",
         "owner": "neutron-org",
         "repo": "neutron",
-        "rev": "e605ed3db4381994ee8185ba4a0ff0877d34e67f",
+        "rev": "d652580f204231a5d6d76c83a084d7110d981416",
         "type": "github"
       },
       "original": {
         "owner": "neutron-org",
-        "ref": "v2.0.0",
+        "ref": "v3.0.2",
         "repo": "neutron",
         "type": "github"
       }
@@ -1392,7 +1393,6 @@
         "stargaze-src": "stargaze-src",
         "stoml-src": "stoml-src",
         "stride-consumer-src": "stride-consumer-src",
-        "stride-src": "stride-src",
         "umee-src": "umee-src",
         "wasmd-src": "wasmd-src",
         "wasmd_next-src": "wasmd_next-src",
@@ -1542,31 +1542,16 @@
     "stride-consumer-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-DByig9ISs9x9Kvakc8LFL558VKhM+UBiaESWgyVzI0w=",
+        "lastModified": 1711572539,
+        "narHash": "sha256-WOoaijuB/Xziw3RMzVcLgR1iDWv72StuLL8K5JzcdlA=",
         "owner": "Stride-Labs",
         "repo": "stride",
-        "rev": "bbf0bb7f52878f3205c76bb1e96662fe7bd7af8d",
+        "rev": "093f25e17b1c9fae38a8092f9582af7c84bbaee4",
         "type": "github"
       },
       "original": {
         "owner": "Stride-Labs",
-        "ref": "v12.1.0",
-        "repo": "stride",
-        "type": "github"
-      }
-    },
-    "stride-src": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-fdjnFHPBZNnhDyVoMuPfqNb6YUYRdcMO73FlZHjIuzA=",
-        "owner": "Stride-Labs",
-        "repo": "stride",
-        "rev": "3c69e7644859981b1fd9313eb1f0c5e5886e4a0d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Stride-Labs",
-        "ref": "v8.0.0",
+        "ref": "v21.0.0",
         "repo": "stride",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -224,10 +224,7 @@
     interchain-security-src.url = "github:cosmos/interchain-security/feat/ics-misbehaviour-handling";
     interchain-security-src.flake = false;
 
-    stride-src.url = "github:Stride-Labs/stride/v8.0.0";
-    stride-src.flake = false;
-
-    stride-consumer-src.url = "github:Stride-Labs/stride/v12.1.0";
+    stride-consumer-src.url = "github:Stride-Labs/stride/v21.0.0";
     stride-consumer-src.flake = false;
 
     migaloo-src.url = "github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2";
@@ -239,7 +236,7 @@
     celestia-node-src.url = "github:celestiaorg/celestia-node/v0.13.0";
     celestia-node-src.flake = false;
 
-    neutron-src.url = "github:neutron-org/neutron/v2.0.0";
+    neutron-src.url = "github:neutron-org/neutron/v3.0.2";
     neutron-src.flake = false;
 
     provenance-src.url = "github:/provenance-io/provenance/v1.17.0";

--- a/flake.nix
+++ b/flake.nix
@@ -224,8 +224,8 @@
     interchain-security-src.url = "github:cosmos/interchain-security/feat/ics-misbehaviour-handling";
     interchain-security-src.flake = false;
 
-    stride-consumer-src.url = "github:Stride-Labs/stride/v21.0.0";
-    stride-consumer-src.flake = false;
+    stride-src.url = "github:Stride-Labs/stride/v21.0.0";
+    stride-src.flake = false;
 
     migaloo-src.url = "github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2";
     migaloo-src.flake = false;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -174,13 +174,13 @@
             type = "app";
             program = "${packages.wasmd}/bin/wasmd";
           };
-          stride-consumer = {
+          stride = {
             type = "app";
-            program = "${packages.stride-consumer}/bin/strided";
+            program = "${packages.stride}/bin/strided";
           };
-          stride-consumer-no-admin = {
+          stride-no-admin = {
             type = "app";
-            program = "${packages.stride-consumer-no-admin}/bin/strided";
+            program = "${packages.stride-no-admin}/bin/strided";
           };
           migaloo = {
             type = "app";

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -174,10 +174,6 @@
             type = "app";
             program = "${packages.wasmd}/bin/wasmd";
           };
-          stride = {
-            type = "app";
-            program = "${packages.stride}/bin/strided";
-          };
           stride-consumer = {
             type = "app";
             program = "${packages.stride-consumer}/bin/strided";
@@ -185,10 +181,6 @@
           stride-consumer-no-admin = {
             type = "app";
             program = "${packages.stride-consumer-no-admin}/bin/strided";
-          };
-          stride-no-admin = {
-            type = "app";
-            program = "${packages.stride-no-admin}/bin/strided";
           };
           migaloo = {
             type = "app";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -109,7 +109,7 @@
         };
         neutron = import ../packages/neutron.nix {
           inherit (inputs) neutron-src;
-          inherit (self'.packages) libwasmvm_1_5_0;
+          inherit (self'.packages) libwasmvm_1_5_2;
           inherit cosmosLib;
         };
         andromeda = import ../packages/andromeda.nix {
@@ -198,7 +198,9 @@
           # Stride
           (import ../packages/stride.nix {
             inherit inputs;
+            inherit (self'.packages) libwasmvm_1_5_2;
             inherit (cosmosLib) mkCosmosGoApp;
+            inherit cosmosLib;
           })
           # Evmos
           (import ../packages/evmos {

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -1,18 +1,18 @@
 {
   neutron-src,
   cosmosLib,
-  libwasmvm_1_5_0,
+  libwasmvm_1_5_2,
 }:
 cosmosLib.mkCosmosGoApp {
-  goVersion = "1.20";
+  goVersion = "1.21";
   name = "neutron";
-  version = "v2.0.0";
+  version = "v3.0.2";
   src = neutron-src;
   rev = neutron-src.rev;
-  vendorHash = "sha256-uLInKbuL886cfXCyQvIDZJHUC8AK9fR39yNBHDO+Qzc=";
+  vendorHash = "sha256-Ao/soQsOw00QZ8c7BF42od303wdiFo30flWSPTm5Mzc=";
   engine = "cometbft/cometbft";
   preFixup = ''
-    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_0 "neutrond"}
+    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "neutrond"}
   '';
-  buildInputs = [libwasmvm_1_5_0];
+  buildInputs = [libwasmvm_1_5_2];
 }

--- a/packages/stride.nix
+++ b/packages/stride.nix
@@ -7,12 +7,12 @@
 with inputs;
   builtins.mapAttrs (_: mkCosmosGoApp)
   {
-    stride-consumer = {
-      name = "stride-consumer";
+    stride = {
+      name = "stride";
       version = "v21.0.0";
       goVersion = "1.21";
-      src = stride-consumer-src;
-      rev = stride-consumer-src.rev;
+      src = stride-src;
+      rev = stride-src.rev;
       vendorHash = "sha256-N3+H90djql3pqyvKM9nlq2XIxUDw7lt9xtWYiKBabro=";
       engine = "cometbft/cometbft";
 
@@ -24,12 +24,12 @@ with inputs;
       doCheck = false;
     };
 
-    stride-consumer-no-admin = {
-      name = "stride-consumer-no-admin";
+    stride-no-admin = {
+      name = "stride-no-admin";
       version = "v21.0.0";
       goVersion = "1.21";
-      src = stride-consumer-src;
-      rev = stride-consumer-src.rev;
+      src = stride-src;
+      rev = stride-src.rev;
       vendorHash = "sha256-N3+H90djql3pqyvKM9nlq2XIxUDw7lt9xtWYiKBabro=";
       engine = "cometbft/cometbft";
 

--- a/packages/stride.nix
+++ b/packages/stride.nix
@@ -1,51 +1,42 @@
 {
   inputs,
   mkCosmosGoApp,
+  cosmosLib,
+  libwasmvm_1_5_2,
 }:
 with inputs;
   builtins.mapAttrs (_: mkCosmosGoApp)
   {
-    stride = {
-      name = "stride";
-      version = "v8.0.0";
-      src = stride-src;
-      rev = stride-src.rev;
-      vendorHash = "sha256-z4vT4CeoJF76GwljHm2L2UF1JxyEJtvqAkP9TmIgs10=";
-      engine = "tendermint/tendermint";
-
-      doCheck = false;
-    };
-
     stride-consumer = {
       name = "stride-consumer";
-      version = "v12.1.0";
+      version = "v21.0.0";
+      goVersion = "1.21";
       src = stride-consumer-src;
       rev = stride-consumer-src.rev;
-      vendorHash = "sha256-tH56oB9Lw0/+ypWRj9n8o/QHPcLQuuNkzD4zFy6bW04=";
+      vendorHash = "sha256-N3+H90djql3pqyvKM9nlq2XIxUDw7lt9xtWYiKBabro=";
       engine = "cometbft/cometbft";
+
+      preFixup = ''
+        ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "strided"}
+      '';
+      buildInputs = [libwasmvm_1_5_2];
 
       doCheck = false;
     };
 
     stride-consumer-no-admin = {
       name = "stride-consumer-no-admin";
-      version = "v12.1.0";
+      version = "v21.0.0";
+      goVersion = "1.21";
       src = stride-consumer-src;
       rev = stride-consumer-src.rev;
-      vendorHash = "sha256-tH56oB9Lw0/+ypWRj9n8o/QHPcLQuuNkzD4zFy6bW04=";
+      vendorHash = "sha256-N3+H90djql3pqyvKM9nlq2XIxUDw7lt9xtWYiKBabro=";
       engine = "cometbft/cometbft";
 
-      patches = [../patches/stride-no-admin-check.patch];
-      doCheck = false;
-    };
-
-    stride-no-admin = {
-      name = "stride-no-admin";
-      version = "v8.0.0";
-      src = stride-src;
-      rev = stride-src.rev;
-      vendorHash = "sha256-z4vT4CeoJF76GwljHm2L2UF1JxyEJtvqAkP9TmIgs10=";
-      engine = "tendermint/tendermint";
+      preFixup = ''
+        ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "strided"}
+      '';
+      buildInputs = [libwasmvm_1_5_2];
 
       patches = [../patches/stride-no-admin-check.patch];
       doCheck = false;

--- a/patches/stride-no-admin-check.patch
+++ b/patches/stride-no-admin-check.patch
@@ -1,13 +1,13 @@
 diff --git a/utils/utils.go b/utils/utils.go
-index 74ff4794..cb2a6f37 100644
+index 0bce89235..dd24c0f83 100644
 --- a/utils/utils.go
 +++ b/utils/utils.go
-@@ -35,9 +35,6 @@ func Int64ToCoinString(amount int64, denom string) string {
+@@ -37,9 +37,6 @@ func Int64ToCoinString(amount int64, denom string) string {
  }
  
  func ValidateAdminAddress(address string) error {
 -	if !Admins[address] {
--		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, fmt.Sprintf("invalid creator address (%s)", address))
+-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, fmt.Sprintf("address (%s) is not an admin", address))
 -	}
  	return nil
  }


### PR DESCRIPTION
This PR does the following:

* Remove Stride before it was a Consumer chain, Stride v8
* Update Stride Consumer chain from v12.1.0 to v21.0.0
* Update Neutron Consumer chain from v2.0.0 to v3.0.2