### PR TITLE
Update Juno to version `v21.0.0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,15 +941,16 @@
     "juno-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-z9TOeDyUnn1T8Z662XqQJ9ydVIKKB54YISt7ms4xvos=",
+        "lastModified": 1709992388,
+        "narHash": "sha256-8VcxdvaaBNyzza6U65PELt8bUII3teruokfbu5j7i9M=",
         "owner": "CosmosContracts",
         "repo": "juno",
-        "rev": "48507ed9b83511089cbf1fdc5bae54cae4a7f4b2",
+        "rev": "e98863bf7112f4b117a2114e22f7482367362764",
         "type": "github"
       },
       "original": {
         "owner": "CosmosContracts",
-        "ref": "v17.1.1",
+        "ref": "v21.0.0",
         "repo": "juno",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
     evmos-src.url = "github:evmos/evmos/v16.0.0-rc4";
     evmos-src.flake = false;
 
-    juno-src.url = "github:CosmosContracts/juno/v17.1.1";
+    juno-src.url = "github:CosmosContracts/juno/v21.0.0";
     juno-src.flake = false;
 
     osmosis-src.url = "github:osmosis-labs/osmosis/v22.0.5";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -99,7 +99,7 @@
         };
         juno = import ../packages/juno.nix {
           inherit (inputs) juno-src;
-          inherit (self'.packages) libwasmvm_1_3_0;
+          inherit (self'.packages) libwasmvm_1_5_2;
           inherit cosmosLib;
         };
         migaloo = import ../packages/migaloo.nix {

--- a/packages/juno.nix
+++ b/packages/juno.nix
@@ -1,20 +1,21 @@
 {
   cosmosLib,
   juno-src,
-  libwasmvm_1_3_0,
+  libwasmvm_1_5_2,
 }:
 cosmosLib.mkCosmosGoApp {
   name = "juno";
-  version = "v17.1.1";
+  version = "v21.0.0";
+  goVersion = "1.21";
   src = juno-src;
   rev = juno-src.rev;
-  vendorHash = "sha256-ftmNMjCFWq4XGM9+ad64dzzcgQJ1ApH4YmthldfrB54=";
+  vendorHash = "sha256-Z5I16c/qRTmJJzAjQp6vmUrSd2F+RV13UYHHnLnhFcE=";
   tags = ["netgo"];
   engine = "cometbft/cometbft";
   excludedPackages = ["interchaintest"];
   preFixup = ''
-    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_3_0 "junod"}
+    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "junod"}
   '';
   dontStrip = true;
-  buildInputs = [libwasmvm_1_3_0];
+  buildInputs = [libwasmvm_1_5_2];
 }


### PR DESCRIPTION
__19.04.2024__

This PR updates Juno from version `v17.1.1` to `v21.0.0` which is the latest on https://cosmos.directory/juno/chain