### PR TITLE
Update Migaloo Chain to version v4.1.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -972,15 +972,16 @@
     "migaloo-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-O+vGWFnV3+bvXinxl1QjVyDnQskp5H1VnlL+TaMfiSs=",
+        "lastModified": 1710414169,
+        "narHash": "sha256-BGOUAw48c92KGpUMvzStiJfd+tgJpTBYk0bAvvUNYL8=",
         "owner": "White-Whale-Defi-Platform",
         "repo": "migaloo-chain",
-        "rev": "de98de2dd96917ae1ab79161d573fc0b4ee1facf",
+        "rev": "5382bfc56173a0f57dcaef34e99c59c99cf70dda",
         "type": "github"
       },
       "original": {
         "owner": "White-Whale-Defi-Platform",
-        "ref": "v3.0.2",
+        "ref": "v4.1.3",
         "repo": "migaloo-chain",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -227,7 +227,7 @@
     stride-src.url = "github:Stride-Labs/stride/v21.0.0";
     stride-src.flake = false;
 
-    migaloo-src.url = "github:White-Whale-Defi-Platform/migaloo-chain/v3.0.2";
+    migaloo-src.url = "github:White-Whale-Defi-Platform/migaloo-chain/v4.1.3";
     migaloo-src.flake = false;
 
     celestia-app-src.url = "github:celestiaorg/celestia-app/v1.4.0";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -104,7 +104,7 @@
         };
         migaloo = import ../packages/migaloo.nix {
           inherit (inputs) migaloo-src;
-          inherit (self'.packages) libwasmvm_1_2_3;
+          inherit (self'.packages) libwasmvm_1_5_2;
           inherit cosmosLib;
         };
         neutron = import ../packages/neutron.nix {

--- a/packages/migaloo.nix
+++ b/packages/migaloo.nix
@@ -1,17 +1,17 @@
 {
   migaloo-src,
   cosmosLib,
-  libwasmvm_1_2_3,
+  libwasmvm_1_5_2,
 }:
 cosmosLib.mkCosmosGoApp {
   name = "migaloo";
-  version = "v3.0.2";
+  version = "v4.1.3";
   src = migaloo-src;
   rev = migaloo-src.rev;
-  vendorHash = "sha256-GQDfI4hSkkrsBfIczdGoOhghR7/FqEvXavyP4E6iHM4=";
-  engine = "tendermint/tendermint";
+  vendorHash = "sha256-2rQm+pVniubKXkH3rXlQUOtgXm2Vp0faaqvU7QpEXN4=";
+  engine = "cometbft/cometbft";
   preFixup = ''
-    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_2_3 "migalood"}
+    ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "migalood"}
   '';
-  buildInputs = [libwasmvm_1_2_3];
+  buildInputs = [libwasmvm_1_5_2];
 }


### PR DESCRIPTION
__19.04.2024__

This PR updates Migaloo Chain from version v3.0.2 to v4.1.3 which is the latest on https://cosmos.directory/migaloo/chain