### PR TITLE
Update ibc-go simapp from `v8.2.0` to `v8.3.1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,16 +812,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712305073,
-        "narHash": "sha256-J/tuv2U6cW+y51gUi4aXzR39lJD/8J/36lf7h2242sU=",
+        "lastModified": 1716359952,
+        "narHash": "sha256-KTjyHwmXA/jgppDKRe85XfRmh8O7AHFKhDyyOb9VROU=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "a2f3d7a78d21641178043341de96c3ecf06fa47b",
+        "rev": "9b6567bf818198ded336490d5f2d89c9d42fd87b",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.2.0",
+        "ref": "v8.3.1",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -131,7 +131,7 @@
     ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.4.0";
     ibc-go-v7-src.flake = false;
 
-    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.2.0";
+    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.3.1";
     ibc-go-v8-src.flake = false;
 
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -76,10 +76,10 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-simapp = {
       name = "simd";
-      version = "v8.2.0";
+      version = "v8.3.1";
       src = ibc-go-v8-src;
       rev = ibc-go-v8-src.rev;
-      vendorHash = "sha256-a88Eu3Oz5byo03ECaDdUXNGom9F/BsWbCRCI1pkp9yQ=";
+      vendorHash = "sha256-SZPjD/7KCmTtlhRV6XdwPG5ArB67mpuJkcSukGKBRPM=";
       goVersion = "1.21";
       tags = ["netgo"];
       engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR updates the ibc-go simapp `v8.2.0` to `v8.3.1`