### PR TITLE
Update Osmosis version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1219,16 +1219,16 @@
     "osmosis-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712687434,
-        "narHash": "sha256-j1PtSv4i/3IV6hUHxxgO/5t9/bfWs28i3D/uVAkf68Q=",
+        "lastModified": 1715157587,
+        "narHash": "sha256-D/CymboICWe73MBGF036W5NT/pyaV8Wvll2bJmYNmHg=",
         "owner": "osmosis-labs",
         "repo": "osmosis",
-        "rev": "0021d3812a8c8d2798ab17e58991a677b82e8955",
+        "rev": "15566f1f2945a16af9243dd376ee58a0d691b66a",
         "type": "github"
       },
       "original": {
         "owner": "osmosis-labs",
-        "ref": "v24.0.1",
+        "ref": "v25.0.0",
         "repo": "osmosis",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,7 @@
     juno-src.url = "github:CosmosContracts/juno/v21.0.0";
     juno-src.flake = false;
 
-    osmosis-src.url = "github:osmosis-labs/osmosis/v24.0.1";
+    osmosis-src.url = "github:osmosis-labs/osmosis/v25.0.0";
     osmosis-src.flake = false;
 
     sentinel-src.url = "github:sentinel-official/hub/v0.9.0-rc0";

--- a/packages/osmosis.nix
+++ b/packages/osmosis.nix
@@ -5,11 +5,11 @@
 }:
 cosmosLib.mkCosmosGoApp {
   name = "osmosis";
-  version = "v24.0.1";
+  version = "v25.0.0";
   goVersion = "1.21";
   src = osmosis-src;
   rev = osmosis-src.rev;
-  vendorHash = "sha256-RjBnaHKge3b1CwIFUFsyE/Yv83QC8UsGtx87mgI1PPo=";
+  vendorHash = "sha256-G/LIUpwWDIwB8oGBnNQ00Y7knoZSYjnON+3+VgIHSQQ=";
   tags = ["netgo"];
   excludedPackages = ["cl-genesis-positions"];
   engine = "cometbft/cometbft";


### PR DESCRIPTION
__10.06.2024__

Update Osmosis version from v24.0.1 to v25.0.0, version tagged as latest in https://github.com/osmosis-labs/osmosis/releases