### PR TITLE
Update Juno version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,16 +941,16 @@
     "juno-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1709992388,
-        "narHash": "sha256-8VcxdvaaBNyzza6U65PELt8bUII3teruokfbu5j7i9M=",
+        "lastModified": 1713701044,
+        "narHash": "sha256-AN9g1t/zOZVs5S/ZXP4/MrIC9kN6nUGG/wLNJz5fL6E=",
         "owner": "CosmosContracts",
         "repo": "juno",
-        "rev": "e98863bf7112f4b117a2114e22f7482367362764",
+        "rev": "b0faafbd6df4bb03940d99df13030af7f7bc315b",
         "type": "github"
       },
       "original": {
         "owner": "CosmosContracts",
-        "ref": "v21.0.0",
+        "ref": "v22.0.0",
         "repo": "juno",
         "type": "github"
       }
@@ -1172,10 +1172,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "narHash": "sha256-FtPPshEpxH/ewBOsdKBNhlsL2MLEFv1hEnQ19f/bFsQ=",
+        "lastModified": 1717868076,
+        "narHash": "sha256-c83Y9t815Wa34khrux81j8K8ET94ESmCuwORSKm2bQY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "rev": "cd18e2ae9ab8e2a0a8d715b60c91b54c0ac35ff9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,15 +35,16 @@
     "apalache-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-Z/tmBMv+QshFJLo2kBgBdkqfKwF93CgURVIbYF3dwJE=",
+        "lastModified": 1714996894,
+        "narHash": "sha256-3xw7bajvhGL+wGne4MRh/HpDFdp+HGfnfzqq8YSx9tc=",
         "owner": "informalsystems",
         "repo": "apalache",
-        "rev": "ec979d4554360faf9d73ddf72dccf350614076d5",
+        "rev": "5dee24e4d05dc3476977a2e49f4963e3802fae2f",
         "type": "github"
       },
       "original": {
         "owner": "informalsystems",
-        "ref": "v0.42.0",
+        "ref": "v0.44.11",
         "repo": "apalache",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708764364,
-        "narHash": "sha256-+pOtDvmuVTg0Gi58hKDUyrNla5NbyUvt3Xs3gLR0Fws=",
+        "lastModified": 1712990762,
+        "narHash": "sha256-hO9W3w7NcnYeX8u8cleHiSpK2YJo7ecarFTUlbybl7k=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "c891f90d2e3c48a6b33466c96e4851e0fc0cf455",
+        "rev": "20aad300c925639d5d6cbe30013c8357ce9f2a2e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,7 @@
     wasmvm_1_beta7-src.url = "github:CosmWasm/wasmvm/v1.0.0-beta7";
     wasmvm_1_beta7-src.flake = false;
 
-    apalache-src.url = "github:informalsystems/apalache/v0.42.0";
+    apalache-src.url = "github:informalsystems/apalache/v0.44.11";
     apalache-src.flake = false;
 
     ignite-cli-src.url = "github:ignite/cli/v0.24.0";

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
     evmos-src.url = "github:evmos/evmos/v16.0.0-rc4";
     evmos-src.flake = false;
 
-    juno-src.url = "github:CosmosContracts/juno/v21.0.0";
+    juno-src.url = "github:CosmosContracts/juno/v22.0.0";
     juno-src.flake = false;
 
     osmosis-src.url = "github:osmosis-labs/osmosis/v24.0.1";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -116,6 +116,7 @@ nix-std: {
     buildGoModuleVersion = {
       "1.20" = pkgs.buildGo120Module;
       "1.21" = pkgs.buildGo121Module;
+      "1.22" = pkgs.buildGo122Module;
     };
 
     buildGoModule = buildGoModuleVersion.${goVersion};

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -75,7 +75,7 @@ nix-std: {
     additionalLdFlags ? [],
     appName ? null,
     preCheck ? null,
-    goVersion ? "1.20",
+    goVersion ? "1.21",
     ...
   }: let
     buildGoModuleArgs =
@@ -114,7 +114,6 @@ nix-std: {
       else appName;
 
     buildGoModuleVersion = {
-      "1.20" = pkgs.buildGo120Module;
       "1.21" = pkgs.buildGo121Module;
       "1.22" = pkgs.buildGo122Module;
     };

--- a/modules/devshells.nix
+++ b/modules/devshells.nix
@@ -12,7 +12,6 @@
     devShells = {
       default = pkgs.mkShell {
         buildInputs = with pkgs; [
-          rnix-lsp
           alejandra
         ];
       };

--- a/modules/devshells.nix
+++ b/modules/devshells.nix
@@ -12,6 +12,7 @@
     devShells = {
       default = pkgs.mkShell {
         buildInputs = with pkgs; [
+          nil
           alejandra
         ];
       };

--- a/packages/andromeda.nix
+++ b/packages/andromeda.nix
@@ -4,7 +4,6 @@
   libwasmvm_1_3_0,
 }:
 cosmosLib.mkCosmosGoApp {
-  goVersion = "1.20";
   name = "andromeda";
   version = "andromeda-1";
   src = andromeda-src;

--- a/packages/apalache.nix
+++ b/packages/apalache.nix
@@ -2,7 +2,7 @@
   apalache-src,
   pkgs,
 }: let
-  version = "v0.42.0";
+  version = "v0.44.11 ";
 
   postPatch = ''
     # Patch the build.sbt file so that it does not call the `git describe` command.
@@ -11,20 +11,20 @@
     # not available, hence the dependency resolution would fail. As a workaround,
     # we use the version string provided in Nix as the build version.
     substituteInPlace ./build.sbt \
-      --replace 'Process("git describe --tags --always").!!.trim' '"${version}"'
+      --replace-warn 'Process("git describe --tags --always").!!.trim' '"${version}"'
 
     # Patch the wrapper script to use a JRE from the Nix store,
     # and to load the JAR from the Nix store by default.
     substituteInPlace ./src/universal/bin/apalache-mc \
-      --replace 'exec java' 'exec ${pkgs.jre}/bin/java' \
-      --replace '$DIR/../lib/apalache.jar' "$out/lib/apalache.jar"
+      --replace-warn 'exec java' 'exec ${pkgs.jre}/bin/java' \
+      --replace-warn '$DIR/../lib/apalache.jar' "$out/lib/apalache.jar"
   '';
 in
   pkgs.mkSbtDerivation {
     inherit version postPatch;
     pname = "apalache";
 
-    depsSha256 = "sha256-1/cI5JK1/uYVK7ihoyZwR4cHJqzsNW9eVaF7OKu92IE=";
+    depsSha256 = "sha256-Bkw/ZV4xYPBR1bx31otb6j14ivg995MsVNEXbYha7B0=";
     src = apalache-src;
     buildPhase = "make dist";
     installPhase = ''

--- a/packages/gaia.nix
+++ b/packages/gaia.nix
@@ -122,7 +122,6 @@
         name = "gaia";
         vendorHash = "sha256-SQF6YNVVOfpL55Uc4LIzo2jv/cdKp8hHUeqcpc/dBEc=";
         version = "v13.0.2";
-        goVersion = "1.20";
         src = gaia13-src;
         rev = gaia13-src.rev;
         tags = ["netgo"];
@@ -137,7 +136,6 @@
         name = "gaia";
         vendorHash = "sha256-7hmP0Uc4HHW7voy3DRMkpAXifon/qnaaT6jaUf/h8HU=";
         version = "v14.0.0";
-        goVersion = "1.20";
         src = gaia14-src;
         rev = gaia14-src.rev;
         tags = ["netgo"];
@@ -152,7 +150,6 @@
         name = "gaia";
         vendorHash = "sha256-3n/tBOEwM9gvrLikJTJN7vzwVL9td+0+2yqgS7jzRd0=";
         version = "v15.2.0";
-        goVersion = "1.20";
         src = gaia15-src;
         rev = gaia15-src.rev;
         tags = ["netgo"];

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -65,7 +65,6 @@ with inputs;
       src = ibc-go-v7-src;
       rev = ibc-go-v7-src.rev;
       vendorHash = "sha256-zjk/75+e/gWSCvpz7lrZkNEDigC/x8czpCSxxbSmWXg=";
-      goVersion = "1.20";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
       excludedPackages = ["./e2e" "./modules/apps/callbacks"];

--- a/packages/injective.nix
+++ b/packages/injective.nix
@@ -4,7 +4,6 @@
   libwasmvm_1_5_0,
 }:
 cosmosLib.mkCosmosGoApp {
-  goVersion = "1.20";
   name = "injective";
   version = "v1.12.1";
   src = injective-src;

--- a/packages/juno.nix
+++ b/packages/juno.nix
@@ -5,11 +5,11 @@
 }:
 cosmosLib.mkCosmosGoApp {
   name = "juno";
-  version = "v21.0.0";
-  goVersion = "1.21";
+  version = "v22.0.0";
+  goVersion = "1.22";
   src = juno-src;
   rev = juno-src.rev;
-  vendorHash = "sha256-Z5I16c/qRTmJJzAjQp6vmUrSd2F+RV13UYHHnLnhFcE=";
+  vendorHash = "sha256-5TTW7ftC5bQgdKOQJtmAQ8GyAuAtTmeFIl+hh12WX4M=";
   tags = ["netgo"];
   engine = "cometbft/cometbft";
   excludedPackages = ["interchaintest"];

--- a/packages/provenance.nix
+++ b/packages/provenance.nix
@@ -6,7 +6,6 @@
 cosmosLib.mkCosmosGoApp {
   name = "provenance";
   version = "v1.17.0";
-  goVersion = "1.20";
   src = provenance-src;
   rev = provenance-src.rev;
   vendorHash = "sha256-XFU/+lMwg4hLlyYGUvDp0SqGqijrUQZddoH4VkIvqHg=";

--- a/packages/rollapp-evm.nix
+++ b/packages/rollapp-evm.nix
@@ -9,6 +9,5 @@ mkCosmosGoApp {
   rev = rollapp-evm-src.rev;
   vendorHash = "sha256-rg3ZrNIMuUUW01lyjklTxn4zYlOiwFXyTqSE7scaRAk=";
   tags = ["netgo"];
-  goVersion = "1.20";
   engine = "cometbft/cometbft";
 }


### PR DESCRIPTION
__10.06.2024__

Update Juno from v21.0.0 to v22.0.0, version tagged as latest in https://github.com/CosmosContracts/juno/releases.

This PR also updates nixpkgs to the latest, with `nix flake lock --update-input nixpkgs` in order to have access to go v1.22.3. This requires the removal of go v1.20 since the attribute `buildGo120Module` is now missing.

This PR also replaced `rnix-lsp` from `devshells.nix`, as it is unmaintained, with oxalica `nil` https://github.com/oxalica/nil/tree/2023-08-09.

This PR also updates Apalache from v0.42.0 to v0.44.11.