### PR TITLE
Update Neutron version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1006,16 +1006,16 @@
     "neutron-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712330928,
-        "narHash": "sha256-3olixILNnkRcNwtpPDqQJ63cYjV5qiVYTM+fJEIH65s=",
+        "lastModified": 1713877185,
+        "narHash": "sha256-cslMi835EdyByhSUN1FG9ucXjh5tQxqs3YfCLqGwYLg=",
         "owner": "neutron-org",
         "repo": "neutron",
-        "rev": "d652580f204231a5d6d76c83a084d7110d981416",
+        "rev": "73f419c3c60a3b811b08788519063560e84d97a8",
         "type": "github"
       },
       "original": {
         "owner": "neutron-org",
-        "ref": "v3.0.2",
+        "ref": "v3.0.5",
         "repo": "neutron",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,7 @@
     celestia-node-src.url = "github:celestiaorg/celestia-node/v0.13.0";
     celestia-node-src.flake = false;
 
-    neutron-src.url = "github:neutron-org/neutron/v3.0.2";
+    neutron-src.url = "github:neutron-org/neutron/v3.0.5";
     neutron-src.flake = false;
 
     provenance-src.url = "github:/provenance-io/provenance/v1.17.0";

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -6,10 +6,10 @@
 cosmosLib.mkCosmosGoApp {
   goVersion = "1.21";
   name = "neutron";
-  version = "v3.0.2";
+  version = "v3.0.5";
   src = neutron-src;
   rev = neutron-src.rev;
-  vendorHash = "sha256-Ao/soQsOw00QZ8c7BF42od303wdiFo30flWSPTm5Mzc=";
+  vendorHash = "sha256-6WV7Z0KbvDReCJ7JccPnRWPkR4BMrfxRouTC5cC6PZc=";
   engine = "cometbft/cometbft";
   preFixup = ''
     ${cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_2 "neutrond"}


### PR DESCRIPTION
Update Neutron from v3.0.2 to v3.0.5, version tagged as latest in https://github.com/neutron-org/neutron/releases