### PR TITLE
Update wasmd from v0.50.0 to v0.51.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1406,7 +1406,8 @@
         "wasmvm_1_3_0-src": "wasmvm_1_3_0-src",
         "wasmvm_1_5_0-src": "wasmvm_1_5_0-src",
         "wasmvm_1_5_2-src": "wasmvm_1_5_2-src",
-        "wasmvm_1_beta7-src": "wasmvm_1_beta7-src"
+        "wasmvm_1_beta7-src": "wasmvm_1_beta7-src",
+        "wasmvm_2_0_0-src": "wasmvm_2_0_0-src"
       }
     },
     "rust-overlay": {
@@ -1648,16 +1649,16 @@
     "wasmd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1700749637,
-        "narHash": "sha256-rKbuaWcRdHXSI+acHrx/hCdGOx5prPd+Dmng4BVrhzs=",
+        "lastModified": 1713797184,
+        "narHash": "sha256-k7c8RdLggeM6hSQhJt0UREY/48T3ZRSSijA+TMFKhUc=",
         "owner": "CosmWasm",
         "repo": "wasmd",
-        "rev": "7ea00e2ea858ed599141e322bd68171998a3259a",
+        "rev": "7b418de3f6cf8fbac1e9cb11c57983fcc17264d0",
         "type": "github"
       },
       "original": {
         "owner": "CosmWasm",
-        "ref": "v0.50.0",
+        "ref": "v0.51.0",
         "repo": "wasmd",
         "type": "github"
       }
@@ -1820,6 +1821,23 @@
       "original": {
         "owner": "CosmWasm",
         "ref": "v1.0.0-beta7",
+        "repo": "wasmvm",
+        "type": "github"
+      }
+    },
+    "wasmvm_2_0_0-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710250586,
+        "narHash": "sha256-OmETCXyhCXWOEW/emf1ZruLMPlH8iLvM8xrqFoDaxnw=",
+        "owner": "CosmWasm",
+        "repo": "wasmvm",
+        "rev": "5307690b77a5fef2da3747ec72abe8f29664aeca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CosmWasm",
+        "ref": "v2.0.0",
         "repo": "wasmvm",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -179,11 +179,14 @@
     composable-cosmos-src.url = "github:ComposableFi/composable-cosmos/v6.4.88";
     composable-cosmos-src.flake = false;
 
-    wasmd-src.url = "github:CosmWasm/wasmd/v0.50.0";
+    wasmd-src.url = "github:CosmWasm/wasmd/v0.51.0";
     wasmd-src.flake = false;
 
     wasmvm_1-src.url = "github:CosmWasm/wasmvm/v1.0.0";
     wasmvm_1-src.flake = false;
+
+    wasmvm_2_0_0-src.url = "github:CosmWasm/wasmvm/v2.0.0";
+    wasmvm_2_0_0-src.flake = false;
 
     wasmvm_1_5_2-src.url = "github:CosmWasm/wasmvm/v1.5.2";
     wasmvm_1_5_2-src.flake = false;

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -166,7 +166,7 @@
         };
         wasmd = import ../packages/wasmd.nix {
           inherit (inputs) wasmd-src;
-          inherit (self'.packages) libwasmvm_1_5_0;
+          inherit (self'.packages) libwasmvm_2_0_0;
           inherit cosmosLib;
         };
         rollapp-evm = import ../packages/rollapp-evm.nix {

--- a/packages/libwasmvm.nix
+++ b/packages/libwasmvm.nix
@@ -17,6 +17,18 @@
 in
   builtins.mapAttrs (_: libwasmvm: pkgs.rustPlatform.buildRustPackage (libwasmvmCommon // libwasmvm))
   {
+    libwasmvm_2_0_0 = {
+      src = "${inputs.wasmvm_2_0_0-src}/libwasmvm";
+      version = "v2.0.0";
+      cargoSha256 = "sha256-BFou131HI+YKXU9H51Xa/y7A441Z7QkAA92mhquJ5l4=";
+      cargoLock = {
+        lockFile = "${inputs.wasmvm_2_0_0-src}/libwasmvm/Cargo.lock";
+        outputHashes = {
+          "cosmwasm-crypto-2.0.0" = "sha256-wXBWwc1jZsO0kfrh0jkl4+TeFsM/8ZkptCEJSpgsLG8=";
+        };
+      };
+    };
+
     libwasmvm_1_5_2 = {
       src = "${inputs.wasmvm_1_5_2-src}/libwasmvm";
       version = "v1.5.2";

--- a/packages/wasmd.nix
+++ b/packages/wasmd.nix
@@ -1,20 +1,20 @@
 {
   wasmd-src,
   cosmosLib,
-  libwasmvm_1_5_0,
+  libwasmvm_2_0_0,
 }:
 cosmosLib.mkCosmosGoApp {
   name = "wasm";
-  version = "v0.50.0";
+  version = "v0.51.0";
   goVersion = "1.21";
   src = wasmd-src;
   rev = wasmd-src.rev;
-  vendorHash = "sha256-IS+WupPaOZgx1iJTHKbX8r6z3/9TsWamTEZCJbVpCOg=";
+  vendorHash = "sha256-hurRN9NUz5Lh1AOpsZNZEKPYAu+6U6GEsYz4ZUh1aAs=";
   tags = ["netgo"];
   engine = "cometbft/cometbft";
-  preFixup = cosmosLib.wasmdPreFixupPhase libwasmvm_1_5_0 "wasmd";
+  preFixup = cosmosLib.wasmdPreFixupPhase libwasmvm_2_0_0 "wasmd";
   dontStrip = true;
-  buildInputs = [libwasmvm_1_5_0];
+  buildInputs = [libwasmvm_2_0_0];
 
   # main module (github.com/CosmWasm/wasmd) does not contain package github.com/CosmWasm/wasmd/tests/system
   excludedPackages = ["tests/system"];


### PR DESCRIPTION
__10.06.2024__

Update wasmd from v0.50.0 to v0.51.0, version tagged as latest in https://github.com/CosmWasm/wasmd/releases

This PR also adds libwasmvm v2.0.0