### PR TITLE
Build ibc-go v9 with wasm enabled

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,7 +183,10 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "nix": "nix",
-        "nixpkgs": ["haqq-src", "nixpkgs-unstable"],
+        "nixpkgs": [
+          "haqq-src",
+          "nixpkgs-unstable"
+        ],
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -641,7 +644,12 @@
     },
     "gitignore": {
       "inputs": {
-        "nixpkgs": ["haqq-src", "devenv", "pre-commit-hooks", "nixpkgs"]
+        "nixpkgs": [
+          "haqq-src",
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
@@ -659,7 +667,9 @@
     "gomod2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1722589758,
@@ -677,8 +687,14 @@
     },
     "gomod2nix_2": {
       "inputs": {
-        "flake-utils": ["haqq-src", "flake-utils"],
-        "nixpkgs": ["haqq-src", "nixpkgs-unstable"]
+        "flake-utils": [
+          "haqq-src",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "haqq-src",
+          "nixpkgs-unstable"
+        ]
       },
       "locked": {
         "narHash": "sha256-yfQQ67dLejP0FLK76LKHbkzcQqNIrux6MFe32MMFGNQ=",
@@ -1064,7 +1080,11 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": ["haqq-src", "devenv", "nixpkgs"],
+        "nixpkgs": [
+          "haqq-src",
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -1099,7 +1119,9 @@
     "nix2container": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1712990762,
@@ -1256,10 +1278,18 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": ["haqq-src", "devenv", "flake-compat"],
+        "flake-compat": [
+          "haqq-src",
+          "devenv",
+          "flake-compat"
+        ],
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
-        "nixpkgs": ["haqq-src", "devenv", "nixpkgs"],
+        "nixpkgs": [
+          "haqq-src",
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -181,7 +181,8 @@
           # IBC Go
           (import ../packages/ibc-go.nix {
             inherit inputs;
-            inherit (cosmosLib) mkCosmosGoApp;
+            inherit (self'.packages) libwasmvm_2_1_0;
+            inherit (cosmosLib) mkCosmosGoApp wasmdPreFixupPhase;
           })
           # Libwasm VM
           (import ../packages/libwasmvm.nix {inherit inputs pkgs system;})

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -1,6 +1,8 @@
 {
   inputs,
+  libwasmvm_2_1_0,
   mkCosmosGoApp,
+  wasmdPreFixupPhase,
 }:
 with inputs;
   builtins.mapAttrs (_: mkCosmosGoApp)
@@ -87,13 +89,17 @@ with inputs;
 
     ibc-go-v9-simapp = {
       name = "simd";
-      version = "v9.0.0-beta.1";
+      version = "v9.0.0-beta.1-wasm";
       src = ibc-go-v9-src;
+      sourceRoot = "source/modules/light-clients/08-wasm";
       rev = ibc-go-v9-src.rev;
-      sourceRoot = "source/simapp";
-      vendorHash = "sha256-gr5Wre8OoSVBR+JNNCvs9zr6T5TwCgSAnchENEgu9qM=";
+      vendorHash = "sha256-uAHvGRXhjydh+c5/M71qRDOYGiHT1ZryvyAgjgHSSo0=";
       goVersion = "1.22";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
+      preFixup = ''
+        ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
+      '';
+      buildInputs = [ libwasmvm_2_1_0 ];
     };
   }

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -100,6 +100,6 @@ with inputs;
       preFixup = ''
         ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
       '';
-      buildInputs = [ libwasmvm_2_1_0 ];
+      buildInputs = [libwasmvm_2_1_0];
     };
   }


### PR DESCRIPTION
This PR update building ibc-go v9 in order to build it with wasm enabled