### PR TITLE
Add Wasm variant of ibc-go v7 and v8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,16 +851,16 @@
     "ibc-go-v7-wasm-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712918303,
-        "narHash": "sha256-VNswGN4sF2cpnB0Wh3VUsXGE/jSSGytp4/3Ufe9HLfc=",
+        "lastModified": 1722365763,
+        "narHash": "sha256-ZYGCvm1Ek1RaXKzkkwQCc56I2HzmbrLR/lFD5IZZdLc=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "7953715f5edf1a05093dd3d324cbb65db6226edd",
+        "rev": "13c071f0b34d67342f0b7a8874d84d2e68b887e1",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "08-wasm/release/v0.1.x+ibc-go-v7.3.x-wasmvm-v1.5.x",
+        "ref": "modules/light-clients/08-wasm/v0.3.1+ibc-go-v7.4-wasmvm-v1.5",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -885,16 +885,16 @@
     "ibc-go-v8-wasm-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1722365763,
-        "narHash": "sha256-ZYGCvm1Ek1RaXKzkkwQCc56I2HzmbrLR/lFD5IZZdLc=",
+        "lastModified": 1722365433,
+        "narHash": "sha256-mgfbibipk09LtO0h0hQDfnVA0cQADaI6Bq+ruyP6xI4=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "13c071f0b34d67342f0b7a8874d84d2e68b887e1",
+        "rev": "ccd4dc278e720be87418028026ebd93a80fa5ac0",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "modules/light-clients/08-wasm/v0.3.1%2Bibc-go-v7.4-wasmvm-v1.5",
+        "ref": "modules/light-clients/08-wasm/v0.4.1+ibc-go-v8.4-wasmvm-v2.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -848,6 +848,23 @@
         "type": "github"
       }
     },
+    "ibc-go-v7-wasm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712918303,
+        "narHash": "sha256-VNswGN4sF2cpnB0Wh3VUsXGE/jSSGytp4/3Ufe9HLfc=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "7953715f5edf1a05093dd3d324cbb65db6226edd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "08-wasm/release/v0.1.x+ibc-go-v7.3.x-wasmvm-v1.5.x",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
@@ -861,6 +878,23 @@
       "original": {
         "owner": "cosmos",
         "ref": "v8.3.1",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
+    "ibc-go-v8-wasm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1722365763,
+        "narHash": "sha256-ZYGCvm1Ek1RaXKzkkwQCc56I2HzmbrLR/lFD5IZZdLc=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "13c071f0b34d67342f0b7a8874d84d2e68b887e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "modules/light-clients/08-wasm/v0.3.1%2Bibc-go-v7.4-wasmvm-v1.5",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -1412,7 +1446,9 @@
         "ibc-go-v5-src": "ibc-go-v5-src",
         "ibc-go-v6-src": "ibc-go-v6-src",
         "ibc-go-v7-src": "ibc-go-v7-src",
+        "ibc-go-v7-wasm-src": "ibc-go-v7-wasm-src",
         "ibc-go-v8-src": "ibc-go-v8-src",
+        "ibc-go-v8-wasm-src": "ibc-go-v8-wasm-src",
         "ibc-go-v9-src": "ibc-go-v9-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   nixConfig = {
     substituters = "https://cosmos-nix.cachix.org https://cache.nixos.org https://nix-community.cachix.org";
-    trusted-public-keys = "cosmosnix.store-1:O28HneR1MPtgY3WYruWFuXCimRPwY7em5s0iynkQxdk= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
+    trusted-public-keys = "cosmos-nix.cachix.org-1:I9dmz4kn5+JExjPxOd9conCzQVHPl0Jo1Cdp6s+63d4= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
   };
 
   description = "A reproducible package set for Cosmos, IBC and CosmWasm";
@@ -146,6 +146,22 @@
 
     ibc-go-v9-src.url = "github:cosmos/ibc-go/v9.0.0-beta.1";
     ibc-go-v9-src.flake = false;
+
+    ibc-go-v7-wasm-src = {
+      type = "github";
+      owner = "cosmos";
+      repo = "ibc-go";
+      ref = "08-wasm/release/v0.1.x+ibc-go-v7.3.x-wasmvm-v1.5.x";
+      flake = false;
+    };
+
+    ibc-go-v8-wasm-src = {
+      type = "github";
+      owner = "cosmos";
+      repo = "ibc-go";
+      ref = "modules/light-clients/08-wasm/v0.3.1%2Bibc-go-v7.4-wasmvm-v1.5";
+      flake = false;
+    };
 
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";
     cosmos-sdk-src.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -151,7 +151,7 @@
       type = "github";
       owner = "cosmos";
       repo = "ibc-go";
-      ref = "08-wasm/release/v0.1.x+ibc-go-v7.3.x-wasmvm-v1.5.x";
+      ref = "modules/light-clients/08-wasm/v0.3.1+ibc-go-v7.4-wasmvm-v1.5";
       flake = false;
     };
 
@@ -159,7 +159,7 @@
       type = "github";
       owner = "cosmos";
       repo = "ibc-go";
-      ref = "modules/light-clients/08-wasm/v0.3.1%2Bibc-go-v7.4-wasmvm-v1.5";
+      ref = "modules/light-clients/08-wasm/v0.4.1+ibc-go-v8.4-wasmvm-v2.0";
       flake = false;
     };
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -126,6 +126,14 @@
             type = "app";
             program = "${packages.ibc-go-v9-simapp}/bin/simd";
           };
+          ibc-go-v7-wasm-simapp = {
+            type = "app";
+            program = "${packages.ibc-go-v7-wasm-simapp}/bin/simd";
+          };
+          ibc-go-v8-wasm-simapp = {
+            type = "app";
+            program = "${packages.ibc-go-v8-wasm-simapp}/bin/simd";
+          };
           ignite-cli = {
             type = "app";
             program = "${packages.ignite-cli}/bin/ignite";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -181,7 +181,7 @@
           # IBC Go
           (import ../packages/ibc-go.nix {
             inherit inputs;
-            inherit (self'.packages) libwasmvm_2_1_0;
+            inherit (self'.packages) libwasmvm_1_5_0 libwasmvm_2_1_0;
             inherit (cosmosLib) mkCosmosGoApp wasmdPreFixupPhase;
           })
           # Libwasm VM

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -110,7 +110,7 @@ with inputs;
       rev = ibc-go-v7-wasm-src.rev;
       vendorHash = "sha256-ERIl4J3a7aD89kcZK1xkcTyZ97qmBQ3YbHEKDjqCJ4c=";
       goVersion = "1.22";
-      tags = [ "netgo" ];
+      tags = ["netgo"];
       engine = "cometbft/cometbft";
       preFixup = ''
         ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
@@ -125,7 +125,7 @@ with inputs;
       rev = ibc-go-v8-wasm-src.rev;
       vendorHash = "sha256-jPd1mjyjFlS3thN0LlpPUhnA6D4UyVkDU+pcJwI9tp0=";
       goVersion = "1.22";
-      tags = [ "netgo" ];
+      tags = ["netgo"];
       engine = "cometbft/cometbft";
       preFixup = ''
         ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -102,4 +102,34 @@ with inputs;
       '';
       buildInputs = [libwasmvm_2_1_0];
     };
+
+    ibc-go-v7-wasm-simapp = {
+      name = "simd";
+      version = "v7.4.0-wasm";
+      src = "${ibc-go-v7-wasm-src}/modules/light-clients/08-wasm";
+      rev = ibc-go-v7-wasm-src.rev;
+      vendorHash = "sha256-ERIl4J3a7aD89kcZK1xkcTyZ97qmBQ3YbHEKDjqCJ4c=";
+      goVersion = "1.22";
+      tags = [ "netgo" ];
+      engine = "cometbft/cometbft";
+      preFixup = ''
+        ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
+      '';
+      buildInputs = [libwasmvm_2_1_0];
+    };
+
+    ibc-go-v8-wasm-simapp = {
+      name = "simd";
+      version = "v8.4.0-wasm";
+      src = "${ibc-go-v8-wasm-src}/modules/light-clients/08-wasm";
+      rev = ibc-go-v8-wasm-src.rev;
+      vendorHash = "sha256-jPd1mjyjFlS3thN0LlpPUhnA6D4UyVkDU+pcJwI9tp0=";
+      goVersion = "1.22";
+      tags = [ "netgo" ];
+      engine = "cometbft/cometbft";
+      preFixup = ''
+        ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
+      '';
+      buildInputs = [libwasmvm_2_1_0];
+    };
   }

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  libwasmvm_1_5_0,
   libwasmvm_2_1_0,
   mkCosmosGoApp,
   wasmdPreFixupPhase,
@@ -108,14 +109,14 @@ with inputs;
       version = "v7.4.0-wasm";
       src = "${ibc-go-v7-wasm-src}/modules/light-clients/08-wasm";
       rev = ibc-go-v7-wasm-src.rev;
-      vendorHash = "sha256-ERIl4J3a7aD89kcZK1xkcTyZ97qmBQ3YbHEKDjqCJ4c=";
+      vendorHash = "sha256-jPd1mjyjFlS3thN0LlpPUhnA6D4UyVkDU+pcJwI9tp0=";
       goVersion = "1.22";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
       preFixup = ''
-        ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
+        ${wasmdPreFixupPhase libwasmvm_1_5_0 "simd"}
       '';
-      buildInputs = [libwasmvm_2_1_0];
+      buildInputs = [libwasmvm_1_5_0];
     };
 
     ibc-go-v8-wasm-simapp = {
@@ -123,7 +124,7 @@ with inputs;
       version = "v8.4.0-wasm";
       src = "${ibc-go-v8-wasm-src}/modules/light-clients/08-wasm";
       rev = ibc-go-v8-wasm-src.rev;
-      vendorHash = "sha256-jPd1mjyjFlS3thN0LlpPUhnA6D4UyVkDU+pcJwI9tp0=";
+      vendorHash = "sha256-z+hmzuAeyVYXtbb3SClfwQW0+nrUiYYYZCP6Vvc4dmQ=";
       goVersion = "1.22";
       tags = ["netgo"];
       engine = "cometbft/cometbft";


### PR DESCRIPTION
This PR supersedes #220 and adds the latest Wasm variant of ibc-go v7 and v8:

- [modules/light-clients/08-wasm/v0.4.1+ibc-go-v8.4-wasmvm-v2.0](https://github.com/cosmos/ibc-go/releases/tag/modules%2Flight-clients%2F08-wasm%2Fv0.4.1%2Bibc-go-v8.4-wasmvm-v2.0)
- [modules/light-clients/08-wasm/v0.3.1+ibc-go-v7.4-wasmvm-v1.5](https://github.com/cosmos/ibc-go/releases/tag/modules%2Flight-clients%2F08-wasm%2Fv0.3.1%2Bibc-go-v7.4-wasmvm-v1.5)