### PR TITLE
Add Gaia v20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1018,16 +1018,17 @@
     "interchain-security-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-adBzn51PKoRsCL9gIzC5Tcqmu7u3GjxTcDj2jpZ/da8=",
+        "lastModified": 1725434145,
+        "narHash": "sha256-GiaTXIYG0ZM5mScV7bEOLf311yYCy/d/YslRosnnzf0=",
         "owner": "cosmos",
         "repo": "interchain-security",
-        "rev": "03aada4af3243dbf739a12adfacc7b37232df694",
+        "rev": "7301916eeafa3700a03d5ddf47a0779801c6d3a1",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "feat/ics-misbehaviour-handling",
         "repo": "interchain-security",
+        "rev": "7301916eeafa3700a03d5ddf47a0779801c6d3a1",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -547,6 +547,23 @@
         "type": "github"
       }
     },
+    "gaia20-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725271426,
+        "narHash": "sha256-ApRAGsbv2+lYKLyeIVHMrx5Gg2VetLXCs8oml0QYhCg=",
+        "owner": "cosmos",
+        "repo": "gaia",
+        "rev": "b5b22dc6e8eef40a6de67d62409601c6e5198fed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "repo": "gaia",
+        "rev": "b5b22dc6e8eef40a6de67d62409601c6e5198fed",
+        "type": "github"
+      }
+    },
     "gaia5-src": {
       "flake": false,
       "locked": {
@@ -1448,6 +1465,7 @@
         "gaia17-src": "gaia17-src",
         "gaia18-src": "gaia18-src",
         "gaia19-src": "gaia19-src",
+        "gaia20-src": "gaia20-src",
         "gaia5-src": "gaia5-src",
         "gaia6-ordered-src": "gaia6-ordered-src",
         "gaia6-src": "gaia6-src",

--- a/flake.lock
+++ b/flake.lock
@@ -101,15 +101,16 @@
     "cometbft-src": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-G5gchJMn/BFzwYx8/ikPDL5fS/TuFIBF4DKJbkalp/M=",
+        "lastModified": 1723450629,
+        "narHash": "sha256-2QO4KeEUX4HHT1AKhEdPplJHjBhalfM11Dn3/urIVig=",
         "owner": "cometbft",
         "repo": "cometbft",
-        "rev": "66a5a9da9f7a3306f382eb9142ccb9c9f7997d3f",
+        "rev": "e1b4453baf0af6487ad187c7f17dc50517126673",
         "type": "github"
       },
       "original": {
         "owner": "cometbft",
-        "ref": "v0.38.0",
+        "ref": "v0.38.11",
         "repo": "cometbft",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -550,17 +550,17 @@
     "gaia20-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725271426,
-        "narHash": "sha256-ApRAGsbv2+lYKLyeIVHMrx5Gg2VetLXCs8oml0QYhCg=",
+        "lastModified": 1726853009,
+        "narHash": "sha256-N7x3k56AtPbIbbJjqKmlEJIytKElALJwj14lZ2pewZg=",
         "owner": "cosmos",
         "repo": "gaia",
-        "rev": "b5b22dc6e8eef40a6de67d62409601c6e5198fed",
+        "rev": "2dba9d471ef73b0a99e844bf55a44ddae700ea06",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
+        "ref": "v20.0.0",
         "repo": "gaia",
-        "rev": "b5b22dc6e8eef40a6de67d62409601c6e5198fed",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1018,17 +1018,17 @@
     "interchain-security-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725434145,
-        "narHash": "sha256-GiaTXIYG0ZM5mScV7bEOLf311yYCy/d/YslRosnnzf0=",
+        "lastModified": 1726849313,
+        "narHash": "sha256-1WEvV3LoXfGvZC9fXOb8mBLKVGCVBiXZcwUewSPit+8=",
         "owner": "cosmos",
         "repo": "interchain-security",
-        "rev": "7301916eeafa3700a03d5ddf47a0779801c6d3a1",
+        "rev": "1e60637f9d8f3505208282416abfbb87fabc4795",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
+        "ref": "v6.1.0",
         "repo": "interchain-security",
-        "rev": "7301916eeafa3700a03d5ddf47a0779801c6d3a1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -268,7 +268,7 @@
     ignite-cli-src.url = "github:ignite/cli/v0.24.0";
     ignite-cli-src.flake = false;
 
-    interchain-security-src.url = "github:cosmos/interchain-security/feat/ics-misbehaviour-handling";
+    interchain-security-src.url = "github:cosmos/interchain-security/7301916eeafa3700a03d5ddf47a0779801c6d3a1";
     interchain-security-src.flake = false;
 
     stride-src.url = "github:Stride-Labs/stride/v23.0.1";

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,9 @@
     gaia-main-src.url = "github:cosmos/gaia";
     gaia-main-src.flake = false;
 
+    gaia20-src.url = "github:cosmos/gaia/b5b22dc6e8eef40a6de67d62409601c6e5198fed";
+    gaia20-src.flake = false;
+
     gaia19-src.url = "github:cosmos/gaia/v19.1.0";
     gaia19-src.flake = false;
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
     gaia-main-src.url = "github:cosmos/gaia";
     gaia-main-src.flake = false;
 
-    gaia20-src.url = "github:cosmos/gaia/b5b22dc6e8eef40a6de67d62409601c6e5198fed";
+    gaia20-src.url = "github:cosmos/gaia/v20.0.0";
     gaia20-src.flake = false;
 
     gaia19-src.url = "github:cosmos/gaia/v19.1.0";

--- a/flake.nix
+++ b/flake.nix
@@ -268,7 +268,7 @@
     ignite-cli-src.url = "github:ignite/cli/v0.24.0";
     ignite-cli-src.flake = false;
 
-    interchain-security-src.url = "github:cosmos/interchain-security/7301916eeafa3700a03d5ddf47a0779801c6d3a1";
+    interchain-security-src.url = "github:cosmos/interchain-security/v6.1.0";
     interchain-security-src.flake = false;
 
     stride-src.url = "github:Stride-Labs/stride/v23.0.1";

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
     sconfig-src.flake = false;
 
     # CometBFT
-    cometbft-src.url = "github:cometbft/cometbft/v0.38.0";
+    cometbft-src.url = "github:cometbft/cometbft/v0.38.11";
     cometbft-src.flake = false;
 
     # Relayer Sources

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -98,6 +98,10 @@
             type = "app";
             program = "${packages.gaia19}/bin/gaiad";
           };
+          gaia20 = {
+            type = "app";
+            program = "${packages.gaia20}/bin/gaiad";
+          };
           gaia-main = {
             type = "app";
             program = "${packages.gaia-main}/bin/gaiad";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -176,7 +176,7 @@
           (import ../packages/gaia.nix {
             inherit inputs cosmosLib;
             inherit (cosmosLib) mkCosmosGoApp;
-            inherit (self'.packages) libwasmvm_1_5_0 libwasmvm_2_0_0;
+            inherit (self'.packages) libwasmvm_1_5_0 libwasmvm_2_0_0 libwasmvm_2_1_2;
           })
           # IBC Go
           (import ../packages/ibc-go.nix {

--- a/packages/cometbft.nix
+++ b/packages/cometbft.nix
@@ -5,6 +5,6 @@
 buildGoModule {
   name = "cometbft";
   src = cometbft-src;
-  vendorHash = "sha256-rZeC0B5U0bdtZAw/hnMJ7XG73jN0nsociAN8GGdmlUY=";
+  vendorHash = "sha256-bQseXRiRup7g7TChMRC3K8tjFLgyqzLWxT9LgsXQnqw=";
   doCheck = false;
 }

--- a/packages/gaia.nix
+++ b/packages/gaia.nix
@@ -3,6 +3,7 @@
   mkCosmosGoApp,
   libwasmvm_1_5_0,
   libwasmvm_2_0_0,
+  libwasmvm_2_1_2,
   cosmosLib,
 }: let
   gaias = with inputs;
@@ -215,6 +216,30 @@
           ${cosmosLib.wasmdPreFixupPhase libwasmvm_2_0_0 "gaiad"}
         '';
         buildInputs = [libwasmvm_2_0_0];
+
+        # Tests have to be disabled because they require Docker to run
+        doCheck = false;
+
+        excludedPackages = ["tests/interchain"];
+      };
+
+      gaia20 = {
+        name = "gaia";
+        vendorHash = "sha256-D7fvLjWUhEr+/wxicdKZthcqRDiop0JxNQaM+Lc9sOM=";
+        version = "v20.0.0-alpha1";
+        # nixpkgs latest go version v1.22 is v1.22.5 but Gaia v20.0.0 requires
+        # v1.22.6 or more so v1.23 is used instead
+        goVersion = "1.23";
+        src = gaia20-src;
+        rev = gaia20-src.rev;
+        tags = ["netgo"];
+        engine = "cometbft/cometbft";
+        proxyVendor = true;
+
+        preFixup = ''
+          ${cosmosLib.wasmdPreFixupPhase libwasmvm_2_1_2 "gaiad"}
+        '';
+        buildInputs = [libwasmvm_2_1_2];
 
         # Tests have to be disabled because they require Docker to run
         doCheck = false;

--- a/packages/gaia.nix
+++ b/packages/gaia.nix
@@ -225,8 +225,8 @@
 
       gaia20 = {
         name = "gaia";
-        vendorHash = "sha256-D7fvLjWUhEr+/wxicdKZthcqRDiop0JxNQaM+Lc9sOM=";
-        version = "v20.0.0-alpha1";
+        vendorHash = "sha256-1WErtwmYr3AgY1lFpiFYrosU4leJ+ZC13Vbk8vwmmg8=";
+        version = "v20.0.0";
         # nixpkgs latest go version v1.22 is v1.22.5 but Gaia v20.0.0 requires
         # v1.22.6 or more so v1.23 is used instead
         goVersion = "1.23";

--- a/packages/interchain-security.nix
+++ b/packages/interchain-security.nix
@@ -5,10 +5,11 @@
 mkCosmosGoApp {
   name = "interchain-security";
   appName = "interchain-security";
-  version = "v3.0.0-pre";
+  version = "v5.5.0-pre";
   src = interchain-security-src;
   rev = interchain-security-src.rev;
-  vendorHash = "sha256-j0xus8vN6bnFMUXyvT8r7ONPQyaEBydKQ8qH2BevWPs=";
+  vendorHash = "sha256-JNyyPbp8XD1gEoyCO7sMB1z7HbER6lfdfnAIq6kiQkQ=";
+  goVersion = "1.22";
   tags = ["netgo"];
   engine = "cometbft/cometbft";
   doCheck = false; # tests are currently failing

--- a/packages/interchain-security.nix
+++ b/packages/interchain-security.nix
@@ -5,10 +5,10 @@
 mkCosmosGoApp {
   name = "interchain-security";
   appName = "interchain-security";
-  version = "v5.5.0-pre";
+  version = "v6.1.0";
   src = interchain-security-src;
   rev = interchain-security-src.rev;
-  vendorHash = "sha256-JNyyPbp8XD1gEoyCO7sMB1z7HbER6lfdfnAIq6kiQkQ=";
+  vendorHash = "sha256-hBKJA5kIw7aHicCcmvzm9pXb+WPjbx5mq7UDPkLLuJ4=";
   goVersion = "1.22";
   tags = ["netgo"];
   engine = "cometbft/cometbft";


### PR DESCRIPTION
### Status

~Currently using latest commit of branch `main`.~ 

~This needs to be updated when the alpha tag for v20 is added to the Gaia repository~

__30.09.2024__

Updated with tag `v20.0.0`

__23.10.2024__

* Add Gaia `v20.0.0`
* Update CometBFT from `v0.38.0` to `v0.38.11`
* Update Interchain Security from `feat/ics-misbehaviour-handling` to `v6.1.0`