### PR TITLE
Update simapp minor versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -919,16 +919,16 @@
     "ibc-go-v9-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723037346,
-        "narHash": "sha256-ba8gbJ0l4l8ZRT9XVN3hTcnxZSb5Fn20p1xiEG4/54c=",
+        "lastModified": 1725262239,
+        "narHash": "sha256-F2p/lIs2/ropKdm0Pebz1kjhRlgwYK0BmDGe/sYec3Y=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "66ebf864d7bfe2193a96c972a9e74196b2ddf104",
+        "rev": "8983f91e519fb1c43d9c9481ba60f11e4ae2b2b0",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v9.0.0-beta.1",
+        "ref": "v9.0.0-rc.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -885,16 +885,16 @@
     "ibc-go-v8-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716359952,
-        "narHash": "sha256-KTjyHwmXA/jgppDKRe85XfRmh8O7AHFKhDyyOb9VROU=",
+        "lastModified": 1726232417,
+        "narHash": "sha256-oIfVmXIOkRqDF4NGmHsh5BELCIzPydAqiz+7urnZ7A4=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "9b6567bf818198ded336490d5f2d89c9d42fd87b",
+        "rev": "6b2554360c0e3f0bbaa59da5b16b29fc05675c57",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v8.3.1",
+        "ref": "v8.5.1",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -834,16 +834,16 @@
     "ibc-go-v6-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712318519,
-        "narHash": "sha256-roRXZEOJIFJiXEQ+a71QdMmqoVJKVk2wvPgHJ9r/mQ8=",
+        "lastModified": 1713970631,
+        "narHash": "sha256-MpBZ/V8agG3/GFJXEY3kSp+FnUw8rX5C613l5D8HXs4=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "8e31269c692d87ac65bfe70cf609925975a57203",
+        "rev": "8cd96f4169ebee21d50ef69417203b21cf4238ab",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v6.3.0",
+        "ref": "v6.3.1",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -851,16 +851,16 @@
     "ibc-go-v7-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1712318559,
-        "narHash": "sha256-uYiUNXLD48v3vRGK6/aQ7z7Ed5hY8VnEBGG/3Uv87Nc=",
+        "lastModified": 1725009574,
+        "narHash": "sha256-6Wpxu4mQaSrQKOLSb3kUpzRrr0aIHVMVEHVwpGJw3sM=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "802ca265dba74a293747e1ccb8b7999aa985af19",
+        "rev": "a5dde80a4ba1c4601aa055a311bf46779104627f",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v7.4.0",
+        "ref": "v7.8.0",
         "repo": "ibc-go",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -138,7 +138,7 @@
     ibc-go-v5-src.url = "github:cosmos/ibc-go/v5.4.0";
     ibc-go-v5-src.flake = false;
 
-    ibc-go-v6-src.url = "github:cosmos/ibc-go/v6.3.0";
+    ibc-go-v6-src.url = "github:cosmos/ibc-go/v6.3.1";
     ibc-go-v6-src.flake = false;
 
     ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.8.0";

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
     ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.8.0";
     ibc-go-v7-src.flake = false;
 
-    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.3.1";
+    ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.5.1";
     ibc-go-v8-src.flake = false;
 
     ibc-go-v9-src.url = "github:cosmos/ibc-go/v9.0.0-beta.1";

--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
     ibc-go-v6-src.url = "github:cosmos/ibc-go/v6.3.0";
     ibc-go-v6-src.flake = false;
 
-    ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.4.0";
+    ibc-go-v7-src.url = "github:cosmos/ibc-go/v7.8.0";
     ibc-go-v7-src.flake = false;
 
     ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.3.1";

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
     ibc-go-v8-src.url = "github:cosmos/ibc-go/v8.5.1";
     ibc-go-v8-src.flake = false;
 
-    ibc-go-v9-src.url = "github:cosmos/ibc-go/v9.0.0-beta.1";
+    ibc-go-v9-src.url = "github:cosmos/ibc-go/v9.0.0-rc.0";
     ibc-go-v9-src.flake = false;
 
     ibc-go-v7-wasm-src = {

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -90,18 +90,14 @@ with inputs;
 
     ibc-go-v9-simapp = {
       name = "simd";
-      version = "v9.0.0-beta.1-wasm";
+      version = "v9.0.0-rc.0";
       src = ibc-go-v9-src;
-      sourceRoot = "source/modules/light-clients/08-wasm";
       rev = ibc-go-v9-src.rev;
-      vendorHash = "sha256-uAHvGRXhjydh+c5/M71qRDOYGiHT1ZryvyAgjgHSSo0=";
+      sourceRoot = "source/simapp";
+      vendorHash = "sha256-tcGoHs2tPcSBgTfyJCF6cvOpLEjDGG38QFxT59JtwI8=";
       goVersion = "1.22";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
-      preFixup = ''
-        ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
-      '';
-      buildInputs = [libwasmvm_2_1_0];
     };
 
     ibc-go-v7-wasm-simapp = {

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -78,10 +78,10 @@ with inputs;
     # the given subdirectory as source
     ibc-go-v8-simapp = {
       name = "simd";
-      version = "v8.3.1";
+      version = "v8.5.1";
       src = ibc-go-v8-src;
       rev = ibc-go-v8-src.rev;
-      vendorHash = "sha256-SZPjD/7KCmTtlhRV6XdwPG5ArB67mpuJkcSukGKBRPM=";
+      vendorHash = "sha256-xWOoahXPDQT4qyojR0LDDFWaOE1rzw2jD/A1xpKOB8g=";
       goVersion = "1.21";
       tags = ["netgo"];
       engine = "cometbft/cometbft";

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -64,10 +64,10 @@ with inputs;
     # package that loads only the given subdirectory as source
     ibc-go-v7-simapp = {
       name = "simd";
-      version = "v7.4.0";
+      version = "v7.8.0";
       src = ibc-go-v7-src;
       rev = ibc-go-v7-src.rev;
-      vendorHash = "sha256-zjk/75+e/gWSCvpz7lrZkNEDigC/x8czpCSxxbSmWXg=";
+      vendorHash = "sha256-4XypqrHthsmhNrEwU0m9wi8Tr7TRPNWgsA+Cdvio5+w=";
       tags = ["netgo"];
       engine = "cometbft/cometbft";
       excludedPackages = ["./e2e" "./modules/apps/callbacks"];

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -51,7 +51,7 @@ with inputs;
 
     ibc-go-v6-simapp = {
       name = "simapp";
-      version = "v6.3.0";
+      version = "v6.3.1";
       src = ibc-go-v6-src;
       rev = ibc-go-v6-src.rev;
       vendorHash = "sha256-IA6W9MaiDi/4wPDXIVO/6xPJwduBwgLiq/yv1zHFBMc=";


### PR DESCRIPTION
Updates the following versions of ibc-go simapp:

* v6: from `v6.3.0` to `v6.3.1`
* v7: from `v7.4.0` to `v7.8.0`
* v8: from `v8.3.1` to `v8.5.1`
* v9: from `v9.0.0-beta.1` to `v9.0.0-rc.0`