### PR TITLE
Add ibc-go-v9 with wasm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,6 +951,23 @@
         "type": "github"
       }
     },
+    "ibc-go-v9-wasm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734690421,
+        "narHash": "sha256-E0LxbmwuGAM3c9OvncRpfvxeQHYbJS2PADGTuI0w38Y=",
+        "owner": "cosmos",
+        "repo": "ibc-go",
+        "rev": "ae2bfabb6df53c000c1212ae41b7d0a0743b851a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "08-wasm/release/v0.5.x%2Bibc-go-v9.0.x-wasmvm-v2.1.x",
+        "repo": "ibc-go",
+        "type": "github"
+      }
+    },
     "ibc-rs-src": {
       "flake": false,
       "locked": {
@@ -1488,6 +1505,7 @@
         "ibc-go-v8-src": "ibc-go-v8-src",
         "ibc-go-v8-wasm-src": "ibc-go-v8-wasm-src",
         "ibc-go-v9-src": "ibc-go-v9-src",
+        "ibc-go-v9-wasm-src": "ibc-go-v9-wasm-src",
         "ibc-rs-src": "ibc-rs-src",
         "ica-src": "ica-src",
         "ignite-cli-src": "ignite-cli-src",
@@ -1534,7 +1552,8 @@
         "wasmvm_2_0_3-src": "wasmvm_2_0_3-src",
         "wasmvm_2_1_0-src": "wasmvm_2_1_0-src",
         "wasmvm_2_1_2-src": "wasmvm_2_1_2-src",
-        "wasmvm_2_1_3-src": "wasmvm_2_1_3-src"
+        "wasmvm_2_1_3-src": "wasmvm_2_1_3-src",
+        "wasmvm_2_1_4-src": "wasmvm_2_1_4-src"
       }
     },
     "rust-overlay": {
@@ -2068,6 +2087,23 @@
       "original": {
         "owner": "CosmWasm",
         "ref": "v2.1.3",
+        "repo": "wasmvm",
+        "type": "github"
+      }
+    },
+    "wasmvm_2_1_4-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733824920,
+        "narHash": "sha256-Bkrp8ocQftzfAAgZ8D8Gifi4qQJl32Urazf4ZAcCnpI=",
+        "owner": "CosmWasm",
+        "repo": "wasmvm",
+        "rev": "1ddd563a80546192e10a9cf38060b5ee5262808e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CosmWasm",
+        "ref": "v2.1.4",
         "repo": "wasmvm",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,14 @@
       flake = false;
     };
 
+    ibc-go-v9-wasm-src = {
+      type = "github";
+      owner = "cosmos";
+      repo = "ibc-go";
+      ref = "08-wasm/release/v0.5.x%2Bibc-go-v9.0.x-wasmvm-v2.1.x";
+      flake = false;
+    };
+
     cosmos-sdk-src.url = "github:cosmos/cosmos-sdk/v0.46.0";
     cosmos-sdk-src.flake = false;
 
@@ -219,6 +227,9 @@
 
     wasmvm_1-src.url = "github:CosmWasm/wasmvm/v1.0.0";
     wasmvm_1-src.flake = false;
+
+    wasmvm_2_1_4-src.url = "github:CosmWasm/wasmvm/v2.1.4";
+    wasmvm_2_1_4-src.flake = false;
 
     wasmvm_2_1_3-src.url = "github:CosmWasm/wasmvm/v2.1.3";
     wasmvm_2_1_3-src.flake = false;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -34,10 +34,6 @@
             type = "app";
             program = "${packages.hermes}/bin/hermes";
           };
-          gaia = {
-            type = "app";
-            program = "${packages.gaia6_0_3}/bin/gaiad";
-          };
           gaia4 = {
             type = "app";
             program = "${packages.gaia4}/bin/gaiad";

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -34,10 +34,6 @@
             type = "app";
             program = "${packages.hermes}/bin/hermes";
           };
-          gaia4 = {
-            type = "app";
-            program = "${packages.gaia4}/bin/gaiad";
-          };
           gaia5 = {
             type = "app";
             program = "${packages.gaia5}/bin/gaiad";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -182,7 +182,7 @@
           # IBC Go
           (import ../packages/ibc-go.nix {
             inherit inputs;
-            inherit (self'.packages) libwasmvm_1_5_0 libwasmvm_2_1_0;
+            inherit (self'.packages) libwasmvm_1_5_0 libwasmvm_2_1_0 libwasmvm_2_1_4;
             inherit (cosmosLib) mkCosmosGoApp wasmdPreFixupPhase;
           })
           # Libwasm VM

--- a/packages/ibc-go.nix
+++ b/packages/ibc-go.nix
@@ -2,6 +2,7 @@
   inputs,
   libwasmvm_1_5_0,
   libwasmvm_2_1_0,
+  libwasmvm_2_1_4,
   mkCosmosGoApp,
   wasmdPreFixupPhase,
 }:
@@ -128,5 +129,20 @@ with inputs;
         ${wasmdPreFixupPhase libwasmvm_2_1_0 "simd"}
       '';
       buildInputs = [libwasmvm_2_1_0];
+    };
+
+    ibc-go-v9-wasm-simapp = {
+      name = "simd";
+      version = "08-wasm/release/v0.5.x%2Bibc-go-v9.0.x-wasmvm-v2.1.x";
+      src = "${ibc-go-v9-wasm-src}/modules/light-clients/08-wasm";
+      rev = ibc-go-v9-wasm-src.rev;
+      vendorHash = "sha256-6ceJhOA2GRgRi+WDt8DN2YhvtUsk4gg1OhG+R/jXJcM=";
+      goVersion = "1.22";
+      tags = ["netgo"];
+      engine = "cometbft/cometbft";
+      preFixup = ''
+        ${wasmdPreFixupPhase libwasmvm_2_1_4 "simd"}
+      '';
+      buildInputs = [libwasmvm_2_1_4];
     };
   }

--- a/packages/libwasmvm.nix
+++ b/packages/libwasmvm.nix
@@ -17,6 +17,18 @@
 in
   builtins.mapAttrs (_: libwasmvm: pkgs.rustPlatform.buildRustPackage (libwasmvmCommon // libwasmvm))
   {
+    libwasmvm_2_1_4 = {
+      src = "${inputs.wasmvm_2_1_4-src}/libwasmvm";
+      version = "v2.1.4";
+      cargoSha256 = "sha256-BFou131HI+YKXU9H51Xa/y7A441Z7QkAA92mhquJ5l4=";
+      cargoLock = {
+        lockFile = "${inputs.wasmvm_2_1_4-src}/libwasmvm/Cargo.lock";
+        outputHashes = {
+          "cosmwasm-crypto-2.1.5" = "sha256-URkpx8+PXZ1IaYnFFC/zBhNd1+FvwNhquR/O5kAyC5U=";
+        };
+      };
+    };
+
     libwasmvm_2_1_3 = {
       src = "${inputs.wasmvm_2_1_3-src}/libwasmvm";
       version = "v2.1.3";


### PR DESCRIPTION
This PR adds ibc-go `v9` with WASM client.

And adds libwasmvm `v2.1.4` as well.

This PR also removes the following from `apps.nix`:
* `gaia` as it was referencing `gaia6_0_3`
* `gaia4`

__Status 08.01.2025__

Since the tag `modules/light-clients/08-wasm` for `v9` was not found the branch `08-wasm/release/v0.5.x%2Bibc-go-v9.0.x-wasmvm-v2.1.x` has been used instead