### PR TITLE
Apalache: bump version pin to v0.50.3, but tla2tools not in nix sandbox

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,23 @@
         "type": "github"
       }
     },
+    "apalache-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756988290,
+        "narHash": "sha256-/04bB3X9q/R2EHA/0pj1lrY5JlpEVbuCgIfltHkjKKM=",
+        "owner": "informalsystems",
+        "repo": "apalache",
+        "rev": "be354704c4788696e9ed9bb262ebca778956a726",
+        "type": "github"
+      },
+      "original": {
+        "owner": "informalsystems",
+        "ref": "v0.50.3",
+        "repo": "apalache",
+        "type": "github"
+      }
+    },
     "celestia-app-src": {
       "flake": false,
       "locked": {
@@ -1426,6 +1443,7 @@
       "inputs": {
         "akash-src": "akash-src",
         "andromeda-src": "andromeda-src",
+        "apalache-src": "apalache-src",
         "celestia-app-src": "celestia-app-src",
         "celestia-node-src": "celestia-node-src",
         "cometbft-src": "cometbft-src",

--- a/flake.nix
+++ b/flake.nix
@@ -292,7 +292,9 @@
     wasmvm_1_beta7-src.url = "github:CosmWasm/wasmvm/v1.0.0-beta7";
     wasmvm_1_beta7-src.flake = false;
 
-    # fails with: [error] [launcher] could not retrieve sbt 1.11.5
+    # fails with:
+    # [error] download error: Caught java.net.UnknownHostException (central.sonatype.com) while downloading https://central.sonatype.com/repository/maven-snapshots/org/lamport/tla2tools/1.7.4/tla2tools-1.7.4.pom
+    # [error] tla2tools.jar not found under https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/
     apalache-src.url = "github:informalsystems/apalache/v0.50.3";
     apalache-src.flake = false;
 

--- a/flake.nix
+++ b/flake.nix
@@ -293,8 +293,8 @@
     wasmvm_1_beta7-src.flake = false;
 
     # fails with: [error] [launcher] could not retrieve sbt 1.11.5
-    #apalache-src.url = "github:informalsystems/apalache/v0.50.1";
-    #apalache-src.flake = false;
+    apalache-src.url = "github:informalsystems/apalache/v0.50.3";
+    apalache-src.flake = false;
 
     ignite-cli-src.url = "github:ignite/cli/v0.24.0";
     ignite-cli-src.flake = false;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -231,13 +231,14 @@
           ## Linux only apps
           ++ (lists.optionals pkgs.stdenv.isLinux
             [
-              # fails with: [error] [launcher] could not retrieve sbt 1.11.5
-              #{
-              #  apalache = {
-              #    type = "app";
-              #    program = "${packages.apalache}/bin/apalache-mc";
-              #  };
-              #}
+              # [error] download error: Caught java.net.UnknownHostException (central.sonatype.com) while downloading https://central.sonatype.com/repository/maven-snapshots/org/lamport/tla2tools/1.7.4/tla2tools-1.7.4.pom
+              # [error] tla2tools.jar not found under https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/
+              {
+                apalache = {
+                  type = "app";
+                  program = "${packages.apalache}/bin/apalache-mc";
+                };
+              }
               {
                 stargaze = {
                   type = "app";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -206,13 +206,14 @@
         ## Linux only packages
         ++ (lists.optionals pkgs.stdenv.isLinux
           [
-            # fails with: [error] [launcher] could not retrieve sbt 1.11.5
-            #{
-            #  apalache = import ../packages/apalache.nix {
-            #    inherit pkgs;
-            #    inherit (inputs) apalache-src;
-            #  };
-            #}
+            # [error] download error: Caught java.net.UnknownHostException (central.sonatype.com) while downloading https://central.sonatype.com/repository/maven-snapshots/org/lamport/tla2tools/1.7.4/tla2tools-1.7.4.pom
+            # [error] tla2tools.jar not found under https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/
+            {
+              apalache = import ../packages/apalache.nix {
+                inherit pkgs;
+                inherit (inputs) apalache-src;
+              };
+            }
             # fails with gaia nill pointer, so need to have config builder for cosmos-sdk too
             # {
             #   hermes-test = import ../nixosTests/tests/hermes-test.nix {

--- a/packages/apalache.nix
+++ b/packages/apalache.nix
@@ -2,7 +2,7 @@
   apalache-src,
   pkgs,
 }: let
-  version = "v0.44.11 ";
+  version = "v0.50.3 ";
   postPatch = ''
     # Patch the build.sbt file so that it does not call the `git describe` command.
     # This is called by sbt-derivation to resolve the Scala dependencies, however
@@ -23,7 +23,7 @@ in
     inherit version postPatch;
     pname = "apalache";
 
-    depsSha256 = "sha256-Bkw/ZV4xYPBR1bx31otb6j14ivg995MsVNEXbYha7B0=";
+    depsSha256 = "sha256-V8Mu/2sdkM17M+5cp7lWt8pIltqnBhsXFTc4rZ5wdkM=";
     src = apalache-src;
     buildPhase = "make dist";
     installPhase = ''


### PR DESCRIPTION
Opening draft PR so others can see where we're at

```
error: Cannot build '/nix/store/ddzff1cbb78j85lqrgp2affpqfgjc4nk-apalache-v0.50.3-.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/5hlzprrcpf2c9yx1i023d9n0gr19mfmw-apalache-v0.50.3-
       Last 25 log lines:
       > [error]      at sbt.Classpaths$.$anonfun$updateTask0$1(Defaults.scala:3989)
       > [error]  at scala.Function1.$anonfun$compose$1(Function1.scala:49)
       > [error]       at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
       > [error]   at sbt.std.Transform$$anon$4.work(Transform.scala:69)
       > [error]   at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
       > [error]     at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
       > [error]         at sbt.Execute.work(Execute.scala:292)
       > [error]  at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
       > [error]     at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
       > [error]  at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
       > [error]       at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
       > [error]   at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
       > [error]    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
       > [error]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
       > [error]    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
       > [error]    at java.base/java.lang.Thread.run(Thread.java:1583)
       > [error] (tlair / update) sbt.librarymanagement.ResolveException: Error downloading org.lamport:tla2tools:1.7.4
       > [error]   Not found
       > [error]   Not found
       > [error]   not found: /build/tmp.3F7xTkg7CJ/project/.ivy/localorg.lamport/tla2tools/1.7.4/ivys/ivy.xml
       > [error]   download error: Caught java.net.UnknownHostException (repo1.maven.org) while downloading https://repo1.maven.org/maven2/org/lamport/tla2tools/1.7.4/tla2tools-1.7.4.pom
       > [error]   download error: Caught java.net.UnknownHostException (central.sonatype.com) while downloading https://central.sonatype.com/repository/maven-snapshots/org/lamport/tla2tools/1.7.4/tla2tools-1.7.4.pom
       > [error]   tla2tools.jar not found under https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/
       > [error] Total time: 1 s, completed Oct 17, 2025, 6:44:33 PM
       > make: *** [Makefile:72: dist] Error 1
       For full logs, run:
         nix log /nix/store/ddzff1cbb78j85lqrgp2affpqfgjc4nk-apalache-v0.50.3-.drv
```